### PR TITLE
Print available line and cell magics separately in LSMagic. 

### DIFF
--- a/kernel/src/main/scala/com/ibm/spark/magic/builtin/BuiltinLoader.scala
+++ b/kernel/src/main/scala/com/ibm/spark/magic/builtin/BuiltinLoader.scala
@@ -17,6 +17,7 @@
 package com.ibm.spark.magic.builtin
 
 import com.google.common.reflect.ClassPath
+import com.google.common.reflect.ClassPath.ClassInfo
 import com.ibm.spark.magic.InternalClassLoader
 import com.google.common.base.Strings._
 import scala.collection.JavaConversions._
@@ -28,8 +29,14 @@ class BuiltinLoader
   extends InternalClassLoader(classOf[BuiltinLoader].getClassLoader) {
 
   private val pkgName = this.getClass.getPackage.getName
-  
-  def getClasses(pkg: String = pkgName) = {
+
+  /**
+   * Provides a list of ClassInfo objects for each class in the specified
+   * package.
+   * @param pkg package name
+   * @return list of ClassInfo objects
+   */
+  def getClasses(pkg: String = pkgName): List[ClassInfo] = {
     isNullOrEmpty(pkg) match {
       case true =>
         List()
@@ -38,7 +45,16 @@ class BuiltinLoader
         val classPath = ClassPath.from(this.getClass.getClassLoader)
         classPath.getTopLevelClasses(pkg).filter(
           _.getSimpleName != this.getClass.getSimpleName
-        )
+        ).toList
     }
   }
+
+  /**
+   * Provides a list of Class[_] objects for each class in the specified
+   * package.
+   * @param pkg package name
+   * @return list of Class[_] objects
+   */
+  def loadClasses(pkg: String = pkgName): List[Class[_]] =
+    getClasses(pkg).map(_.load())
 }

--- a/kernel/src/test/scala/com/ibm/spark/magic/builtin/BuiltinLoaderSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/magic/builtin/BuiltinLoaderSpec.scala
@@ -28,5 +28,13 @@ class BuiltinLoaderSpec extends FunSpec with Matchers with MockitoSugar {
         classes.size shouldNot be(0)
       }
     }
+
+    describe("#loadClasses") {
+      it("should return class objects for classes in a package") {
+        val pkg = this.getClass.getPackage.getName
+        val classes = new BuiltinLoader().loadClasses(pkg).toList
+        classes.contains(this.getClass) should be (true)
+      }
+    }
   }
 }

--- a/kernel/src/test/scala/com/ibm/spark/magic/builtin/LSMagicSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/magic/builtin/LSMagicSpec.scala
@@ -1,0 +1,65 @@
+package com.ibm.spark.magic.builtin
+
+import java.io.OutputStream
+import java.net.URL
+
+import com.ibm.spark.interpreter.Interpreter
+import com.ibm.spark.magic.dependencies.{IncludeOutputStream, IncludeInterpreter, IncludeSparkContext}
+import com.ibm.spark.magic.{CellMagic, LineMagic}
+import org.apache.spark.SparkContext
+import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.mock.MockitoSugar
+
+import org.mockito.Mockito._
+import org.mockito.Matchers._
+
+class TestLSMagic(sc: SparkContext, intp: Interpreter, os: OutputStream)
+  extends LSMagic
+  with IncludeSparkContext
+  with IncludeInterpreter
+  with IncludeOutputStream
+  {
+    override val sparkContext: SparkContext = sc
+    override val interpreter: Interpreter = intp
+    override val outputStream: OutputStream = os
+  }
+
+class LSMagicSpec extends FunSpec with Matchers with MockitoSugar {
+  describe("LSMagic") {
+
+    describe("#execute") {
+      it("should call println with a magics message") {
+        val lsm = spy(new TestLSMagic(
+          mock[SparkContext], mock[Interpreter], mock[OutputStream])
+        )
+        val classList = new BuiltinLoader().loadClasses()
+        lsm.execute("")
+        verify(lsm).magicNames("%", classOf[LineMagic], classList)
+        verify(lsm).magicNames("%%", classOf[CellMagic], classList)
+      }
+    }
+
+    describe("#magicNames") {
+      it("should filter classnames by interface") {
+        val prefix = "%"
+        val interface = classOf[LineMagic]
+        val classes : List[Class[_]] = List(classOf[LSMagic], classOf[Integer])
+        val lsm = new TestLSMagic(
+          mock[SparkContext], mock[Interpreter], mock[OutputStream])
+        lsm.magicNames(prefix, interface, classes).length should be(1)
+      }
+      it("should prepend prefix to each name"){
+        val prefix = "%"
+        val className = classOf[LSMagic].getSimpleName
+        val interface = classOf[LineMagic]
+        val expected = s"${prefix}${className}"
+        val classes : List[Class[_]] = List(classOf[LSMagic], classOf[Integer])
+        val lsm = new TestLSMagic(
+          mock[SparkContext], mock[Interpreter], mock[OutputStream])
+        lsm.magicNames(prefix, interface, classes) should be(List(expected))
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR is for issue #29. It contains an implementation of `%lsmagic` that prints line and cell magics separately, adhering with IPython's format. It also contains tests for `LSMagic` and `BuiltinLoader`.

example output:

![lsmagic](https://cloud.githubusercontent.com/assets/680489/5826021/323e94b4-a0b5-11e4-8530-c36e065d82d9.png)


@cjm5325 @rcsenkbeil any thoughts?