### PR TITLE
Changed ENTRYPOINT to allow existing JVM_OPT value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get --no-install-recommends -y --force-yes install openjdk-7-jre mesos=0
 ENV MESOS_NATIVE_LIBRARY /usr/local/lib/libmesos.so
 
 #   Setup the binary we will run
-ENTRYPOINT JVM_OPT=-Dlog4j.logLevel=${LOG_LEVEL} /app/bin/sparkkernel
+ENTRYPOINT JVM_OPT="${JVM_OPT} -Dlog4j.logLevel=${LOG_LEVEL}" /app/bin/sparkkernel
 
 #   Install the pack elements
 ADD kernel/target/pack /app


### PR DESCRIPTION
This fixes the problem of passing in JVM_OPT and it being overshadowed by the ENTRYPOINT line in the dockerfile.