### PR TITLE
Fix magics needing kernel interpreter

### DIFF
--- a/kernel-api/src/main/scala/com/ibm/spark/magic/dependencies/DependencyMap.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/magic/dependencies/DependencyMap.scala
@@ -50,6 +50,20 @@ class DependencyMap {
   }
 
   /**
+   * Sets the Interpreter for this map.
+   * @param interpreter The new Interpreter
+   */
+  def setKernelInterpreter(interpreter: Interpreter) = {
+    internalMap(typeOf[IncludeKernelInterpreter]) =
+      PartialFunction[Magic, Unit](
+        magic =>
+          magic.asInstanceOf[IncludeKernelInterpreter].kernelInterpreter_=(interpreter)
+      )
+
+    this
+  }
+
+  /**
    * Sets the SparkContext for this map.
    * @param sparkContext The new SparkContext
    */

--- a/kernel-api/src/main/scala/com/ibm/spark/magic/dependencies/IncludeKernelInterpreter.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/magic/dependencies/IncludeKernelInterpreter.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.spark.magic.dependencies
+
+import com.ibm.spark.interpreter.Interpreter
+import com.ibm.spark.magic.Magic
+
+trait IncludeKernelInterpreter {
+  this: Magic =>
+
+  //val interpreter: Interpreter
+  private var _interpreter: Interpreter = _
+  def kernelInterpreter: Interpreter = _interpreter
+  def kernelInterpreter_=(newInterpreter: Interpreter) =
+    _interpreter = newInterpreter
+}

--- a/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
+++ b/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
@@ -85,7 +85,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
       config, appName, actorLoader, interpreter)
     val dependencyDownloader = initializeDependencyDownloader(config)
     val magicLoader = initializeMagicLoader(
-      config, interpreter, sparkContext, dependencyDownloader)
+      config, interpreter, kernelInterpreter, sparkContext, dependencyDownloader)
     val kernel = initializeKernel(
       actorLoader, interpreter, kernelInterpreter, commManager, magicLoader)
     val responseMap = initializeResponseMap()
@@ -295,7 +295,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
   }
 
   private def initializeMagicLoader(
-    config: Config, interpreter: Interpreter, sparkContext: SparkContext,
+    config: Config, interpreter: Interpreter, kernelInterpreter: Interpreter, sparkContext: SparkContext,
     dependencyDownloader: DependencyDownloader
   ) = {
     logger.debug("Constructing magic loader")
@@ -304,6 +304,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
     val dependencyMap = new DependencyMap()
       .setInterpreter(interpreter)
       .setSparkContext(sparkContext)
+      .setKernelInterpreter(kernelInterpreter)
       .setDependencyDownloader(dependencyDownloader)
 
     logger.debug("Creating BuiltinLoader")

--- a/kernel/src/test/scala/com/ibm/spark/magic/builtin/RDDSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/magic/builtin/RDDSpec.scala
@@ -17,9 +17,9 @@
 package com.ibm.spark.magic.builtin
 
 import com.ibm.spark.interpreter.Results.Result
-import com.ibm.spark.interpreter.{ExecuteAborted, ExecuteError, Interpreter}
+import com.ibm.spark.interpreter.{Results, ExecuteAborted, ExecuteError, Interpreter}
 import com.ibm.spark.kernel.protocol.v5.MIMEType
-import com.ibm.spark.magic.dependencies.IncludeInterpreter
+import com.ibm.spark.magic.dependencies.{IncludeKernelInterpreter, IncludeInterpreter}
 import org.apache.spark.sql.{SchemaRDD, StructType}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -43,13 +43,14 @@ class RDDSpec extends FunSpec with Matchers with MockitoSugar with BeforeAndAfte
   doReturn(mockRdd).when(mockSchemaRdd).map(any())(any())
   doReturn(rows).when(mockRdd).take(anyInt())
 
-  val rddMagic = new RDD with IncludeInterpreter {
-    override val interpreter: Interpreter = mockInterpreter
+  val rddMagic = new RDD with IncludeKernelInterpreter {
+    override val kernelInterpreter: Interpreter = mockInterpreter
   }
 
   before {
+    doReturn("someRDD").when(mockInterpreter).mostRecentVar
     doReturn(Some(mockSchemaRdd)).when(mockInterpreter).read(anyString())
-    doReturn((mock[Result], Left(resOutput)))
+    doReturn((Results.Success, Left(resOutput)))
       .when(mockInterpreter).interpret(anyString(), anyBoolean())
   }
 


### PR DESCRIPTION
This pull request adds a new trait for Magics that need to interpret code. The problem is the current interpreter trait exposes the interpreter that is currently executing the magic code, which is locked. With this new trait magics will have a field exposed to them for an interpreter that will not be blocked during their execution.