### PR TITLE
[defect #125] Support arbitrary JSON in the comm message data field

### DIFF
--- a/client/src/test/scala/com/ibm/spark/comm/ClientCommManagerSpec.scala
+++ b/client/src/test/scala/com/ibm/spark/comm/ClientCommManagerSpec.scala
@@ -64,7 +64,7 @@ class ClientCommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
   describe("ClientCommManager") {
     describe("#open") {
       it("should return a wrapped instance of ClientCommWriter") {
-        clientCommManager.open(TestTargetName, v5.Data())
+        clientCommManager.open(TestTargetName, v5.MsgData.Empty)
 
         // Exposed hackishly for testing
         generatedCommWriter shouldBe a [ClientCommWriter]

--- a/client/src/test/scala/com/ibm/spark/comm/ClientCommWriterSpec.scala
+++ b/client/src/test/scala/com/ibm/spark/comm/ClientCommWriterSpec.scala
@@ -125,7 +125,7 @@ class ClientCommWriterSpec extends TestKit(
       }
 
       it("should provide empty data in the message if no data is provided") {
-        val expected = Data()
+        val expected = MsgData.Empty
         clientCommWriter.writeOpen(anyString())
 
         val actual = getNextMessageContents[CommOpen].data
@@ -134,7 +134,7 @@ class ClientCommWriterSpec extends TestKit(
       }
 
       it("should include the data in the message") {
-        val expected = Data("some key" -> "some value")
+        val expected = MsgData("some key" -> "some value")
         clientCommWriter.writeOpen(anyString(), expected)
 
         val actual = getNextMessageContents[CommOpen].data
@@ -145,14 +145,14 @@ class ClientCommWriterSpec extends TestKit(
 
     describe("#writeMsg") {
       it("should send a comm_msg message to the relay") {
-        clientCommWriter.writeMsg(Data())
+        clientCommWriter.writeMsg(MsgData.Empty)
 
         getNextMessageType should be (CommMsg.toTypeString)
       }
 
       it("should include the comm_id in the message") {
         val expected = commId
-        clientCommWriter.writeMsg(Data())
+        clientCommWriter.writeMsg(MsgData.Empty)
 
         val actual = getNextMessageContents[CommMsg].comm_id
 
@@ -166,7 +166,7 @@ class ClientCommWriterSpec extends TestKit(
       }
 
       it("should include the data in the message") {
-        val expected = Data("some key" -> "some value")
+        val expected = MsgData("some key" -> "some value")
         clientCommWriter.writeMsg(expected)
 
         val actual = getNextMessageContents[CommMsg].data
@@ -192,7 +192,7 @@ class ClientCommWriterSpec extends TestKit(
       }
 
       it("should provide empty data in the message if no data is provided") {
-        val expected = Data()
+        val expected = MsgData.Empty
         clientCommWriter.writeClose()
 
         val actual = getNextMessageContents[CommClose].data
@@ -201,7 +201,7 @@ class ClientCommWriterSpec extends TestKit(
       }
 
       it("should include the data in the message") {
-        val expected = Data("some key" -> "some value")
+        val expected = MsgData("some key" -> "some value")
         clientCommWriter.writeClose(expected)
 
         val actual = getNextMessageContents[CommClose].data
@@ -227,7 +227,7 @@ class ClientCommWriterSpec extends TestKit(
       }
 
       it("should package the string as part of the data with a 'message' key") {
-        val expected = Data("message" -> "a")
+        val expected = MsgData("message" -> "a")
         clientCommWriter.write(Array('a'), 0, 1)
 
         val actual = getNextMessageContents[CommMsg].data
@@ -260,7 +260,7 @@ class ClientCommWriterSpec extends TestKit(
       }
 
       it("should provide empty data in the message") {
-        val expected = Data()
+        val expected = MsgData.Empty
         clientCommWriter.close()
 
         val actual = getNextMessageContents[CommClose].data

--- a/client/src/test/scala/com/ibm/spark/kernel/protocol/v5/client/socket/IOPubClientSpec.scala
+++ b/client/src/test/scala/com/ibm/spark/kernel/protocol/v5/client/socket/IOPubClientSpec.scala
@@ -103,7 +103,7 @@ class IOPubClientSpec extends TestKit(ActorSystem(
       it("should execute all Comm open callbacks on comm_open message") {
         val message: ZMQMessage = kmBuilder
           .withHeader(CommOpen.toTypeString)
-          .withContentString(CommOpen(TestCommId, TestTargetName, v5.Data()))
+          .withContentString(CommOpen(TestCommId, TestTargetName, v5.MsgData.Empty))
           .build
 
         // Mark as target being provided
@@ -117,14 +117,14 @@ class IOPubClientSpec extends TestKit(ActorSystem(
         eventually {
           verify(mockCommCallbacks).executeOpenCallbacks(
             any[CommWriter], mockEq(TestCommId),
-            mockEq(TestTargetName), any[v5.Data])
+            mockEq(TestTargetName), any[v5.MsgData])
         }
       }
 
       it("should not execute Comm open callbacks if the target is not found") {
         val message: ZMQMessage = kmBuilder
           .withHeader(CommOpen.toTypeString)
-          .withContentString(CommOpen(TestCommId, TestTargetName, v5.Data()))
+          .withContentString(CommOpen(TestCommId, TestTargetName, v5.MsgData.Empty))
           .build
 
         // Mark as target NOT being provided
@@ -140,7 +140,7 @@ class IOPubClientSpec extends TestKit(ActorSystem(
 
           verify(mockCommCallbacks, never()).executeOpenCallbacks(
             any[CommWriter], mockEq(TestCommId),
-            mockEq(TestTargetName), any[v5.Data])
+            mockEq(TestTargetName), any[v5.MsgData])
           verify(mockCommRegistrar, never()).link(TestTargetName, TestCommId)
         }
       }
@@ -148,7 +148,7 @@ class IOPubClientSpec extends TestKit(ActorSystem(
       it("should execute all Comm msg callbacks on comm_msg message") {
         val message: ZMQMessage = kmBuilder
           .withHeader(CommMsg.toTypeString)
-          .withContentString(CommMsg(TestCommId, v5.Data()))
+          .withContentString(CommMsg(TestCommId, v5.MsgData.Empty))
           .build
 
         // Mark as target being provided
@@ -161,14 +161,14 @@ class IOPubClientSpec extends TestKit(ActorSystem(
         // Check to see if "eventually" the callback is triggered
         eventually {
           verify(mockCommCallbacks).executeMsgCallbacks(
-            any[CommWriter], mockEq(TestCommId), any[v5.Data])
+            any[CommWriter], mockEq(TestCommId), any[v5.MsgData])
         }
       }
 
       it("should not execute Comm msg callbacks if the Comm id is not found") {
         val message: ZMQMessage = kmBuilder
           .withHeader(CommMsg.toTypeString)
-          .withContentString(CommMsg(TestCommId, v5.Data()))
+          .withContentString(CommMsg(TestCommId, v5.MsgData.Empty))
           .build
 
         // Mark as target NOT being provided
@@ -183,14 +183,14 @@ class IOPubClientSpec extends TestKit(ActorSystem(
           verify(spyCommStorage).getCommIdCallbacks(TestCommId)
 
           verify(mockCommCallbacks, never()).executeMsgCallbacks(
-            any[CommWriter], mockEq(TestCommId), any[v5.Data])
+            any[CommWriter], mockEq(TestCommId), any[v5.MsgData])
         }
       }
 
       it("should execute all Comm close callbacks on comm_close message") {
         val message: ZMQMessage = kmBuilder
           .withHeader(CommClose.toTypeString)
-          .withContentString(CommClose(TestCommId, v5.Data()))
+          .withContentString(CommClose(TestCommId, v5.MsgData.Empty))
           .build
 
         // Mark as target being provided
@@ -203,14 +203,14 @@ class IOPubClientSpec extends TestKit(ActorSystem(
         // Check to see if "eventually" the callback is triggered
         eventually {
           verify(mockCommCallbacks).executeCloseCallbacks(
-            any[CommWriter], mockEq(TestCommId), any[v5.Data])
+            any[CommWriter], mockEq(TestCommId), any[v5.MsgData])
         }
       }
 
       it("should not execute Comm close callbacks if Comm id is not found") {
         val message: ZMQMessage = kmBuilder
           .withHeader(CommClose.toTypeString)
-          .withContentString(CommClose(TestCommId, v5.Data()))
+          .withContentString(CommClose(TestCommId, v5.MsgData.Empty))
           .build
 
         // Mark as target NOT being provided
@@ -225,7 +225,7 @@ class IOPubClientSpec extends TestKit(ActorSystem(
           verify(spyCommStorage).getCommIdCallbacks(TestCommId)
 
           verify(mockCommCallbacks, never()).executeCloseCallbacks(
-            any[CommWriter], mockEq(TestCommId), any[v5.Data])
+            any[CommWriter], mockEq(TestCommId), any[v5.MsgData])
         }
       }
 

--- a/kernel/src/test/scala/com/ibm/spark/comm/KernelCommManagerSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/comm/KernelCommManagerSpec.scala
@@ -64,7 +64,7 @@ class KernelCommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
   describe("KernelCommManager") {
     describe("#open") {
       it("should return a wrapped instance of KernelCommWriter") {
-        kernelCommManager.open(TestTargetName, v5.Data())
+        kernelCommManager.open(TestTargetName, v5.MsgData.Empty)
 
         // Exposed hackishly for testing
         generatedCommWriter shouldBe a [KernelCommWriter]

--- a/kernel/src/test/scala/com/ibm/spark/comm/KernelCommWriterSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/comm/KernelCommWriterSpec.scala
@@ -123,7 +123,7 @@ class KernelCommWriterSpec extends TestKit(
       }
 
       it("should provide empty data in the message if no data is provided") {
-        val expected = Data()
+        val expected = MsgData.Empty
         kernelCommWriter.writeOpen(anyString())
 
         val actual = getNextMessageContents[CommOpen].data
@@ -132,7 +132,7 @@ class KernelCommWriterSpec extends TestKit(
       }
 
       it("should include the data in the message") {
-        val expected = Data("some key" -> "some value")
+        val expected = MsgData("some key" -> "some value")
         kernelCommWriter.writeOpen(anyString(), expected)
 
         val actual = getNextMessageContents[CommOpen].data
@@ -143,14 +143,14 @@ class KernelCommWriterSpec extends TestKit(
 
     describe("#writeMsg") {
       it("should send a comm_msg message to the relay") {
-        kernelCommWriter.writeMsg(Data())
+        kernelCommWriter.writeMsg(MsgData.Empty)
 
         getNextMessageType should be (CommMsg.toTypeString)
       }
 
       it("should include the comm_id in the message") {
         val expected = commId
-        kernelCommWriter.writeMsg(Data())
+        kernelCommWriter.writeMsg(MsgData.Empty)
 
         val actual = getNextMessageContents[CommMsg].comm_id
 
@@ -164,7 +164,7 @@ class KernelCommWriterSpec extends TestKit(
       }
 
       it("should include the data in the message") {
-        val expected = Data("some key" -> "some value")
+        val expected = MsgData("some key" -> "some value")
         kernelCommWriter.writeMsg(expected)
 
         val actual = getNextMessageContents[CommMsg].data
@@ -190,7 +190,7 @@ class KernelCommWriterSpec extends TestKit(
       }
 
       it("should provide empty data in the message if no data is provided") {
-        val expected = Data()
+        val expected = MsgData.Empty
         kernelCommWriter.writeClose()
 
         val actual = getNextMessageContents[CommClose].data
@@ -199,7 +199,7 @@ class KernelCommWriterSpec extends TestKit(
       }
 
       it("should include the data in the message") {
-        val expected = Data("some key" -> "some value")
+        val expected = MsgData("some key" -> "some value")
         kernelCommWriter.writeClose(expected)
 
         val actual = getNextMessageContents[CommClose].data
@@ -225,7 +225,7 @@ class KernelCommWriterSpec extends TestKit(
       }
 
       it("should package the string as part of the data with a 'message' key") {
-        val expected = Data("message" -> "a")
+        val expected = MsgData("message" -> "a")
         kernelCommWriter.write(Array('a'), 0, 1)
 
         val actual = getNextMessageContents[CommMsg].data
@@ -258,7 +258,7 @@ class KernelCommWriterSpec extends TestKit(
       }
 
       it("should provide empty data in the message") {
-        val expected = Data()
+        val expected = MsgData.Empty
         kernelCommWriter.close()
 
         val actual = getNextMessageContents[CommClose].data

--- a/kernel/src/test/scala/com/ibm/spark/kernel/protocol/v5/handler/CommCloseHandlerSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/kernel/protocol/v5/handler/CommCloseHandlerSpec.scala
@@ -83,7 +83,7 @@ class CommCloseHandlerSpec extends TestKit(
         // Send a comm_open message with the test target
         commCloseHandler ! kmBuilder
           .withHeader(CommClose.toTypeString)
-          .withContentString(CommClose(TestCommId, v5.Data()))
+          .withContentString(CommClose(TestCommId, v5.MsgData.Empty))
           .build
 
         // Should receive a busy and an idle message
@@ -91,7 +91,7 @@ class CommCloseHandlerSpec extends TestKit(
 
         // Verify that the msg callbacks were triggered along the way
         verify(mockCommCallbacks).executeCloseCallbacks(
-          any[CommWriter], any[v5.UUID], any[v5.Data])
+          any[CommWriter], any[v5.UUID], any[v5.MsgData])
       }
 
       it("should not execute close callbacks if the id is not registered") {
@@ -101,7 +101,7 @@ class CommCloseHandlerSpec extends TestKit(
         // Send a comm_msg message with the test id
         commCloseHandler ! kmBuilder
           .withHeader(CommClose.toTypeString)
-          .withContentString(CommClose(TestCommId, v5.Data()))
+          .withContentString(CommClose(TestCommId, v5.MsgData.Empty))
           .build
 
         // Should receive a busy and an idle message
@@ -109,7 +109,7 @@ class CommCloseHandlerSpec extends TestKit(
 
         // Verify that the msg callbacks were NOT triggered along the way
         verify(mockCommCallbacks, never()).executeCloseCallbacks(
-          any[CommWriter], any[v5.UUID], any[v5.Data])
+          any[CommWriter], any[v5.UUID], any[v5.MsgData])
       }
 
       it("should do nothing if there is a parsing error") {

--- a/kernel/src/test/scala/com/ibm/spark/kernel/protocol/v5/handler/CommMsgHandlerSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/kernel/protocol/v5/handler/CommMsgHandlerSpec.scala
@@ -81,7 +81,7 @@ class CommMsgHandlerSpec extends TestKit(
         // Send a comm_open message with the test target
         commMsgHandler ! kmBuilder
           .withHeader(CommMsg.toTypeString)
-          .withContentString(CommMsg(TestCommId, v5.Data()))
+          .withContentString(CommMsg(TestCommId, v5.MsgData.Empty))
           .build
 
         // Should receive a busy and an idle message
@@ -89,7 +89,7 @@ class CommMsgHandlerSpec extends TestKit(
 
         // Verify that the msg callbacks were triggered along the way
         verify(mockCommCallbacks).executeMsgCallbacks(
-          any[CommWriter], any[v5.UUID], any[v5.Data])
+          any[CommWriter], any[v5.UUID], any[v5.MsgData])
       }
 
       it("should not execute msg callbacks if the id is not registered") {
@@ -99,7 +99,7 @@ class CommMsgHandlerSpec extends TestKit(
         // Send a comm_msg message with the test id
         commMsgHandler ! kmBuilder
           .withHeader(CommMsg.toTypeString)
-          .withContentString(CommMsg(TestCommId, v5.Data()))
+          .withContentString(CommMsg(TestCommId, v5.MsgData.Empty))
           .build
 
         // Should receive a busy and an idle message
@@ -107,7 +107,7 @@ class CommMsgHandlerSpec extends TestKit(
 
         // Verify that the msg callbacks were NOT triggered along the way
         verify(mockCommCallbacks, never()).executeMsgCallbacks(
-          any[CommWriter], any[v5.UUID], any[v5.Data])
+          any[CommWriter], any[v5.UUID], any[v5.MsgData])
       }
 
       it("should do nothing if there is a parsing error") {

--- a/kernel/src/test/scala/com/ibm/spark/kernel/protocol/v5/handler/CommOpenHandlerSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/kernel/protocol/v5/handler/CommOpenHandlerSpec.scala
@@ -84,7 +84,7 @@ class CommOpenHandlerSpec extends TestKit(
         // Send a comm_open message with the test target
         commOpenHandler ! kmBuilder
           .withHeader(CommOpen.toTypeString)
-          .withContentString(CommOpen(TestCommId, TestTargetName, v5.Data()))
+          .withContentString(CommOpen(TestCommId, TestTargetName, v5.MsgData.Empty))
           .build
 
         // Should receive a busy and an idle message
@@ -92,7 +92,7 @@ class CommOpenHandlerSpec extends TestKit(
 
         // Verify that the open callbacks were triggered along the way
         verify(mockCommCallbacks).executeOpenCallbacks(
-          any[CommWriter], any[v5.UUID], anyString(), any[v5.Data])
+          any[CommWriter], any[v5.UUID], anyString(), any[v5.MsgData])
       }
 
       it("should close the comm connection if the target does not exist") {
@@ -102,7 +102,7 @@ class CommOpenHandlerSpec extends TestKit(
         // Send a comm_open message with the test target
         commOpenHandler ! kmBuilder
           .withHeader(CommOpen.toTypeString)
-          .withContentString(CommOpen(TestCommId, TestTargetName, v5.Data()))
+          .withContentString(CommOpen(TestCommId, TestTargetName, v5.MsgData.Empty))
           .build
 
         // Should receive a close message as a result of the target missing

--- a/kernel/src/test/scala/system/TruncationTests.scala
+++ b/kernel/src/test/scala/system/TruncationTests.scala
@@ -131,7 +131,7 @@ class TruncationTests
   // Not using TestCommId to avoid problems if previous comm using that
   // id in tests was not properly closed
   private def buildZMQCommOpen(
-    targetName: String, data: v5.Data,
+    targetName: String, data: v5.MsgData,
     commId: v5.UUID = java.util.UUID.randomUUID().toString
   ): (v5.UUID, ZMQMessage) = {
     val kernelMessage = KMBuilder()
@@ -147,7 +147,7 @@ class TruncationTests
 
   // Not using TestCommId to avoid problems if previous comm using that
   // id in tests was not properly closed
-  private def buildZMQCommMsg(commId: v5.UUID, data: v5.Data): (v5.UUID, ZMQMessage) = {
+  private def buildZMQCommMsg(commId: v5.UUID, data: v5.MsgData): (v5.UUID, ZMQMessage) = {
     val kernelMessage = KMBuilder()
       .withHeader(CommMsg.toTypeString)
       .withContentString(CommMsg(
@@ -160,7 +160,7 @@ class TruncationTests
 
   // Not using TestCommId to avoid problems if previous comm using that
   // id in tests was not properly closed
-  private def buildZMQCommClose(commId: v5.UUID, data: v5.Data): (v5.UUID, ZMQMessage) = {
+  private def buildZMQCommClose(commId: v5.UUID, data: v5.MsgData): (v5.UUID, ZMQMessage) = {
     val kernelMessage = KMBuilder()
       .withHeader(CommClose.toTypeString)
       .withContentString(CommClose(

--- a/protocol/src/main/scala/com/ibm/spark/comm/CommCallbacks.scala
+++ b/protocol/src/main/scala/com/ibm/spark/comm/CommCallbacks.scala
@@ -22,9 +22,9 @@ import scala.util.Try
 
 @Experimental
 object CommCallbacks {
-  type OpenCallback = (CommWriter, UUID, String, Data) => Unit
-  type MsgCallback = (CommWriter, UUID, Data) => Unit
-  type CloseCallback = (CommWriter, UUID, Data) => Unit
+  type OpenCallback = (CommWriter, UUID, String, MsgData) => Unit
+  type MsgCallback = (CommWriter, UUID, MsgData) => Unit
+  type CloseCallback = (CommWriter, UUID, MsgData) => Unit
 }
 
 import com.ibm.spark.comm.CommCallbacks._
@@ -139,7 +139,7 @@ class CommCallbacks(
    * @return The sequence of results from trying to execute callbacks
    */
   def executeOpenCallbacks(
-    commWriter: CommWriter, commId: UUID, targetName: String, data: Data
+    commWriter: CommWriter, commId: UUID, targetName: String, data: MsgData
   ) = openCallbacks.map(f => Try(f(commWriter, commId, targetName, data)))
 
   /**
@@ -151,7 +151,7 @@ class CommCallbacks(
    *
    * @return The sequence of results from trying to execute callbacks
    */
-  def executeMsgCallbacks(commWriter: CommWriter, commId: UUID, data: Data) =
+  def executeMsgCallbacks(commWriter: CommWriter, commId: UUID, data: MsgData) =
     msgCallbacks.map(f => Try(f(commWriter, commId, data)))
 
   /**
@@ -163,6 +163,6 @@ class CommCallbacks(
    *
    * @return The sequence of results from trying to execute callbacks
    */
-  def executeCloseCallbacks(commWriter: CommWriter, commId: UUID, data: Data) =
+  def executeCloseCallbacks(commWriter: CommWriter, commId: UUID, data: MsgData) =
     closeCallbacks.map(f => Try(f(commWriter, commId, data)))
 }

--- a/protocol/src/main/scala/com/ibm/spark/comm/CommManager.scala
+++ b/protocol/src/main/scala/com/ibm/spark/comm/CommManager.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import com.ibm.spark.annotations.Experimental
 import com.ibm.spark.comm.CommCallbacks.{CloseCallback, OpenCallback}
 import com.ibm.spark.kernel.protocol.v5
-import com.ibm.spark.kernel.protocol.v5.{Data, KernelMessageContent}
+import com.ibm.spark.kernel.protocol.v5._
 import com.ibm.spark.kernel.protocol.v5.content.CommContent
 
 /**
@@ -62,7 +62,7 @@ abstract class CommManager(private val commRegistrar: CommRegistrar) {
     ](commContent: T): Unit = commWriter.sendCommKernelMessage(commContent)
 
     // Overridden to unlink before sending close message
-    override def writeClose(data: Data): Unit = {
+    override def writeClose(data: MsgData): Unit = {
       unlinkFunc(this, this.commId, data)
       commWriter.writeClose(data)
     }
@@ -74,12 +74,12 @@ abstract class CommManager(private val commRegistrar: CommRegistrar) {
     }
 
     // Overriden to link before sending open message
-    override def writeOpen(targetName: String, data: Data): Unit = {
+    override def writeOpen(targetName: String, data: MsgData): Unit = {
       linkFunc(this, this.commId, targetName, data)
       commWriter.writeOpen(targetName, data)
     }
 
-    override def writeMsg(data: Data): Unit = commWriter.writeMsg(data)
+    override def writeMsg(data: MsgData): Unit = commWriter.writeMsg(data)
     override def write(cbuf: Array[Char], off: Int, len: Int): Unit =
       commWriter.write(cbuf, off, len)
     override def flush(): Unit = commWriter.flush()
@@ -142,7 +142,7 @@ abstract class CommManager(private val commRegistrar: CommRegistrar) {
    *
    * @return The new CommWriter representing the connection
    */
-  def open(targetName: String, data: v5.Data = v5.Data()): CommWriter = {
+  def open(targetName: String, data: v5.MsgData = v5.MsgData.Empty): CommWriter = {
     val commId = UUID.randomUUID().toString
 
     // Create our CommWriter and wrap it to establish links and unlink on close

--- a/protocol/src/main/scala/com/ibm/spark/comm/CommWriter.scala
+++ b/protocol/src/main/scala/com/ibm/spark/comm/CommWriter.scala
@@ -16,6 +16,7 @@
 package com.ibm.spark.comm
 
 import com.ibm.spark.annotations.Experimental
+import com.ibm.spark.kernel.protocol.v5
 import com.ibm.spark.kernel.protocol.v5._
 import com.ibm.spark.kernel.protocol.v5.content._
 
@@ -40,7 +41,7 @@ abstract class CommWriter(
    * @param targetName The name of the target (used by the recipient)
    * @param data The optional data to send with the open message
    */
-  def writeOpen(targetName: String, data: Data = Data()) =
+  def writeOpen(targetName: String, data: MsgData = MsgData.Empty) =
     sendCommKernelMessage(CommOpen(commId, targetName, data))
 
   /**
@@ -48,7 +49,7 @@ abstract class CommWriter(
    *
    * @param data The data to send
    */
-  def writeMsg(data: Data) = {
+  def writeMsg(data: v5.MsgData) = {
     require(data != null)
 
     sendCommKernelMessage(CommMsg(commId, data))
@@ -59,7 +60,7 @@ abstract class CommWriter(
    *
    * @param data The optional data to send with the close message
    */
-  def writeClose(data: Data = Data()) =
+  def writeClose(data: v5.MsgData = MsgData.Empty) =
     sendCommKernelMessage(CommClose(commId, data))
 
   /**
@@ -93,7 +94,7 @@ abstract class CommWriter(
    * @return The resulting CommMsg wrapper
    */
   private def packageMessage(message: String) =
-    CommMsg(commId, Data(MessageFieldName -> message))
+    CommMsg(commId, MsgData(MessageFieldName -> message))
 
   /**
    * Sends the comm message (open/msg/close) to the actor responsible for

--- a/protocol/src/main/scala/com/ibm/spark/kernel/protocol/v5/content/CommClose.scala
+++ b/protocol/src/main/scala/com/ibm/spark/kernel/protocol/v5/content/CommClose.scala
@@ -16,10 +16,10 @@
 
 package com.ibm.spark.kernel.protocol.v5.content
 
-import com.ibm.spark.kernel.protocol.v5.{KernelMessageContent, Data, UUID}
+import com.ibm.spark.kernel.protocol.v5._
 import play.api.libs.json.Json
 
-case class CommClose(comm_id: UUID, data: Data)
+case class CommClose(comm_id: UUID, data: MsgData)
   extends KernelMessageContent with CommContent
 {
   override def content : String =

--- a/protocol/src/main/scala/com/ibm/spark/kernel/protocol/v5/content/CommMsg.scala
+++ b/protocol/src/main/scala/com/ibm/spark/kernel/protocol/v5/content/CommMsg.scala
@@ -16,10 +16,10 @@
 
 package com.ibm.spark.kernel.protocol.v5.content
 
-import com.ibm.spark.kernel.protocol.v5.{KernelMessageContent, Data, UUID}
+import com.ibm.spark.kernel.protocol.v5.{MsgData, KernelMessageContent, UUID}
 import play.api.libs.json.Json
 
-case class CommMsg(comm_id: UUID, data: Data)
+case class CommMsg(comm_id: UUID, data: MsgData)
   extends KernelMessageContent with CommContent
 {
   override def content : String =

--- a/protocol/src/main/scala/com/ibm/spark/kernel/protocol/v5/content/CommOpen.scala
+++ b/protocol/src/main/scala/com/ibm/spark/kernel/protocol/v5/content/CommOpen.scala
@@ -16,10 +16,10 @@
 
 package com.ibm.spark.kernel.protocol.v5.content
 
-import com.ibm.spark.kernel.protocol.v5.{KernelMessageContent, Data, UUID}
+import com.ibm.spark.kernel.protocol.v5._
 import play.api.libs.json.Json
 
-case class CommOpen(comm_id: UUID, target_name: String, data: Data)
+case class CommOpen(comm_id: UUID, target_name: String, data: MsgData)
   extends KernelMessageContent with CommContent
 {
   override def content : String =

--- a/protocol/src/main/scala/com/ibm/spark/kernel/protocol/v5/package.scala
+++ b/protocol/src/main/scala/com/ibm/spark/kernel/protocol/v5/package.scala
@@ -17,6 +17,7 @@
 package com.ibm.spark.kernel.protocol
 
 import com.ibm.spark.kernel.protocol.v5.MIMEType.MIMEType
+import play.api.libs.json.{JsValue, Json, JsObject}
 
 package object v5 {
   // Provide a UUID type representing a string (there is no object)
@@ -42,6 +43,13 @@ package object v5 {
   type Payloads = List[Map[String, String]]
   val Payloads = List
 
+  // Provide a MsgData type representing an arbitrary JSON value
+  type MsgData = JsValue
+  val MsgData = new {
+    def apply(xs: (String, Json.JsValueWrapper)*) = Json.obj(xs: _*)
+
+    val Empty = Json.obj()
+  }
 
   // TODO: Split this into client/server socket types and move them to their
   //       respective projects

--- a/protocol/src/test/scala/com/ibm/spark/comm/CommCallbacksSpec.scala
+++ b/protocol/src/test/scala/com/ibm/spark/comm/CommCallbacksSpec.scala
@@ -96,14 +96,14 @@ class CommCallbacksSpec extends FunSpec with Matchers {
     describe("#executeOpenCallbacks") {
       it("should return an empty sequence of results if no callbacks exist") {
         new CommCallbacks()
-          .executeOpenCallbacks(null, "", "", Data()) shouldBe empty
+          .executeOpenCallbacks(null, "", "", MsgData.Empty) shouldBe empty
       }
 
       it("should return a sequence of try results if callbacks exist") {
         val commCallbacks = new CommCallbacks()
           .addOpenCallback(testOpenCallback)
 
-        val results = commCallbacks.executeOpenCallbacks(null, "", "", Data())
+        val results = commCallbacks.executeOpenCallbacks(null, "", "", MsgData.Empty)
 
         results.head.isSuccess should be (true)
       }
@@ -112,7 +112,7 @@ class CommCallbacksSpec extends FunSpec with Matchers {
         val commCallbacks = new CommCallbacks()
           .addOpenCallback(failOpenCallback)
 
-        val results = commCallbacks.executeOpenCallbacks(null, "", "", Data())
+        val results = commCallbacks.executeOpenCallbacks(null, "", "", MsgData.Empty)
 
         results.head.isFailure should be (true)
       }
@@ -121,14 +121,14 @@ class CommCallbacksSpec extends FunSpec with Matchers {
     describe("#executeMsgCallbacks") {
       it("should return an empty sequence of results if no callbacks exist") {
         new CommCallbacks()
-          .executeMsgCallbacks(null, "", Data()) shouldBe empty
+          .executeMsgCallbacks(null, "", MsgData.Empty) shouldBe empty
       }
 
       it("should return a sequence of try results if callbacks exist") {
         val commCallbacks = new CommCallbacks()
           .addMsgCallback(testMsgCallback)
 
-        val results = commCallbacks.executeMsgCallbacks(null, "", Data())
+        val results = commCallbacks.executeMsgCallbacks(null, "", MsgData.Empty)
 
         results.head.isSuccess should be (true)
       }
@@ -137,7 +137,7 @@ class CommCallbacksSpec extends FunSpec with Matchers {
         val commCallbacks = new CommCallbacks()
           .addMsgCallback(failMsgCallback)
 
-        val results = commCallbacks.executeMsgCallbacks(null, "", Data())
+        val results = commCallbacks.executeMsgCallbacks(null, "", MsgData.Empty)
 
         results.head.isFailure should be (true)
       }
@@ -146,14 +146,14 @@ class CommCallbacksSpec extends FunSpec with Matchers {
     describe("#executeCloseCallbacks") {
       it("should return an empty sequence of results if no callbacks exist") {
         new CommCallbacks()
-          .executeCloseCallbacks(null, "", Data()) shouldBe empty
+          .executeCloseCallbacks(null, "", MsgData.Empty) shouldBe empty
       }
 
       it("should return a sequence of try results if callbacks exist") {
         val commCallbacks = new CommCallbacks()
           .addCloseCallback(testCloseCallback)
 
-        val results = commCallbacks.executeCloseCallbacks(null, "", Data())
+        val results = commCallbacks.executeCloseCallbacks(null, "", MsgData.Empty)
 
         results.head.isSuccess should be (true)
       }
@@ -162,7 +162,7 @@ class CommCallbacksSpec extends FunSpec with Matchers {
         val commCallbacks = new CommCallbacks()
           .addCloseCallback(failCloseCallback)
 
-        val results = commCallbacks.executeCloseCallbacks(null, "", Data())
+        val results = commCallbacks.executeCloseCallbacks(null, "", MsgData.Empty)
 
         results.head.isFailure should be (true)
       }

--- a/protocol/src/test/scala/com/ibm/spark/comm/CommManagerSpec.scala
+++ b/protocol/src/test/scala/com/ibm/spark/comm/CommManagerSpec.scala
@@ -93,7 +93,7 @@ class CommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
         verify(mockCommRegistrar).addOpenHandler(any(classOf[OpenCallback]))
 
         // Trigger the callback to test what it does
-        linkFunc(mock[CommWriter], TestCommId, TestTargetName, v5.Data())
+        linkFunc(mock[CommWriter], TestCommId, TestTargetName, v5.MsgData.Empty)
         verify(mockCommRegistrar).link(TestTargetName, TestCommId)
       }
 
@@ -114,7 +114,7 @@ class CommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
         verify(mockCommRegistrar).addCloseHandler(any(classOf[CloseCallback]))
 
         // Trigger the callback to test what it does
-        unlinkFunc(mock[CommWriter], TestCommId, v5.Data())
+        unlinkFunc(mock[CommWriter], TestCommId, v5.MsgData.Empty)
         verify(mockCommRegistrar).unlink(TestCommId)
       }
     }
@@ -169,7 +169,7 @@ class CommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
 
     describe("#open") {
       it("should return a new CommWriter instance that links during open") {
-        val commWriter = commManager.open(TestTargetName, v5.Data())
+        val commWriter = commManager.open(TestTargetName, v5.MsgData.Empty)
 
         commWriter.writeOpen(TestTargetName)
 
@@ -180,17 +180,17 @@ class CommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
       }
 
       it("should return a new CommWriter instance that unlinks during close") {
-        val commWriter = commManager.open(TestTargetName, v5.Data())
+        val commWriter = commManager.open(TestTargetName, v5.MsgData.Empty)
 
-        commWriter.writeClose(v5.Data())
+        commWriter.writeClose(v5.MsgData.Empty)
 
         verify(mockCommRegistrar).unlink(any[v5.UUID])
       }
 
       it("should initiate a comm_open") {
-        commManager.open(TestTargetName, v5.Data())
+        commManager.open(TestTargetName, v5.MsgData.Empty)
 
-        verify(mockCommWriter).writeOpen(TestTargetName, v5.Data())
+        verify(mockCommWriter).writeOpen(TestTargetName, v5.MsgData.Empty)
       }
     }
   }

--- a/protocol/src/test/scala/com/ibm/spark/comm/CommWriterSpec.scala
+++ b/protocol/src/test/scala/com/ibm/spark/comm/CommWriterSpec.scala
@@ -57,7 +57,7 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
         commWriter.writeOpen("")
 
         verify(commWriter).sendCommKernelMessage(
-          CommOpen(comm_id = expected, target_name = "", data = Data()))
+          CommOpen(comm_id = expected, target_name = "", data = MsgData.Empty))
       }
 
       it("should include the target name in the message") {
@@ -65,11 +65,14 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
         commWriter.writeOpen(expected)
 
         verify(commWriter).sendCommKernelMessage(
-          CommOpen(comm_id = TestCommId, target_name = expected, data = Data()))
+          CommOpen(
+            comm_id = TestCommId, target_name = expected, data = MsgData.Empty
+          )
+        )
       }
 
       it("should provide empty data in the message if no data is provided") {
-        val expected: v5.Data = Data()
+        val expected: v5.MsgData = MsgData.Empty
         commWriter.writeOpen("")
 
         verify(commWriter).sendCommKernelMessage(
@@ -77,7 +80,7 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
       }
 
       it("should include the data in the message") {
-        val expected = Data("some key" -> "some value")
+        val expected = MsgData("message" -> "a", "foo" -> "bar")
         commWriter.writeOpen("", expected)
 
         verify(commWriter).sendCommKernelMessage(
@@ -87,17 +90,17 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
 
     describe("#writeMsg") {
       it("should send a comm_msg message to the relay") {
-        commWriter.writeMsg(Data())
+        commWriter.writeMsg(MsgData.Empty)
 
         verify(commWriter).sendCommKernelMessage(any[CommMsg])
       }
 
       it("should include the comm_id in the message") {
         val expected = TestCommId
-        commWriter.writeMsg(Data())
+        commWriter.writeMsg(MsgData.Empty)
 
         verify(commWriter).sendCommKernelMessage(
-          CommMsg(comm_id = expected, data = Data()))
+          CommMsg(comm_id = expected, data = MsgData.Empty))
       }
 
       it("should fail a require if the data is null") {
@@ -107,7 +110,7 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
       }
 
       it("should include the data in the message") {
-        val expected = Data("some key" -> "some value")
+        val expected = MsgData("message" -> "a")
         commWriter.writeMsg(expected)
 
         verify(commWriter).sendCommKernelMessage(
@@ -127,11 +130,11 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
         commWriter.writeClose()
 
         verify(commWriter).sendCommKernelMessage(
-          CommClose(comm_id = expected, data = Data()))
+          CommClose(comm_id = expected, data = MsgData.Empty))
       }
 
       it("should provide empty data in the message if no data is provided") {
-        val expected: v5.Data = Data()
+        val expected: v5.MsgData = MsgData.Empty
         commWriter.writeClose()
 
         verify(commWriter).sendCommKernelMessage(
@@ -139,7 +142,7 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
       }
 
       it("should include the data in the message") {
-        val expected = Data("some key" -> "some value")
+        val expected = MsgData("message" -> "a")
         commWriter.writeClose(expected)
 
         verify(commWriter).sendCommKernelMessage(
@@ -156,7 +159,7 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
 
       it("should include the comm_id in the message") {
         val expected = TestCommId
-        val messageData = Data("message" -> "a")
+        val messageData = MsgData("message" -> "a")
         commWriter.write(Array('a'), 0, 1)
 
         verify(commWriter).sendCommKernelMessage(
@@ -164,7 +167,7 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
       }
 
       it("should package the string as part of the data with a 'message' key") {
-        val expected = Data("message" -> "a")
+        val expected = MsgData("message" -> "a")
         commWriter.write(Array('a'), 0, 1)
 
         verify(commWriter).sendCommKernelMessage(
@@ -191,11 +194,11 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
         commWriter.close()
 
         verify(commWriter).sendCommKernelMessage(
-          CommClose(comm_id = expected, data = Data()))
+          CommClose(comm_id = expected, data = MsgData.Empty))
       }
 
       it("should provide empty data in the message") {
-        val expected: v5.Data = Data()
+        val expected: v5.MsgData = MsgData.Empty
         commWriter.close()
 
         verify(commWriter).sendCommKernelMessage(

--- a/protocol/src/test/scala/com/ibm/spark/kernel/protocol/v5/content/CommCloseSpec.scala
+++ b/protocol/src/test/scala/com/ibm/spark/kernel/protocol/v5/content/CommCloseSpec.scala
@@ -16,7 +16,7 @@
 
 package com.ibm.spark.kernel.protocol.v5.content
 
-import com.ibm.spark.kernel.protocol.v5.Data
+import com.ibm.spark.kernel.protocol.v5._
 import org.scalatest.{FunSpec, Matchers}
 import play.api.data.validation.ValidationError
 import play.api.libs.json._
@@ -30,7 +30,7 @@ class CommCloseSpec extends FunSpec with Matchers {
   """)
 
   val commClose = CommClose(
-    "<UUID>", Data()
+    "<UUID>", MsgData.Empty
   )
 
   describe("CommClose") {

--- a/protocol/src/test/scala/com/ibm/spark/kernel/protocol/v5/content/CommMsgSpec.scala
+++ b/protocol/src/test/scala/com/ibm/spark/kernel/protocol/v5/content/CommMsgSpec.scala
@@ -19,7 +19,7 @@ package com.ibm.spark.kernel.protocol.v5.content
 import org.scalatest.{FunSpec, Matchers}
 import play.api.data.validation.ValidationError
 import play.api.libs.json._
-import com.ibm.spark.kernel.protocol.v5.Data
+import com.ibm.spark.kernel.protocol.v5._
 
 class CommMsgSpec extends FunSpec with Matchers {
   val commMsgJson: JsValue = Json.parse("""
@@ -29,8 +29,30 @@ class CommMsgSpec extends FunSpec with Matchers {
   }
   """)
 
+  val commMsgJsonWithData: JsValue = Json.parse(
+    """
+    {
+      "comm_id": "<UUID>",
+      "data": {
+        "key" : {
+          "foo" : "bar",
+          "baz" : {
+            "qux" : 3
+          }
+        }
+      }
+    }
+    """.stripMargin)
+
   val commMsg = CommMsg(
-    "<UUID>", Data()
+    "<UUID>", MsgData.Empty
+  )
+
+  val commMsgWithData = CommMsg(
+    "<UUID>", MsgData("key" -> Json.obj(
+      "foo" -> "bar",
+      "baz" -> Map("qux" -> 3)
+    ))
   )
 
   describe("CommMsg") {
@@ -44,6 +66,11 @@ class CommMsgSpec extends FunSpec with Matchers {
       it("should implicitly convert from valid json to a CommMsg instance") {
         // This is the least safe way to convert as an error is thrown if it fails
         commMsgJson.as[CommMsg] should be (commMsg)
+      }
+
+      it("should implicitly convert json with a non-empty json data field " +
+         "to a CommMsg instance") {
+        commMsgJsonWithData.as[CommMsg] should be (commMsgWithData)
       }
 
       it("should also work with asOpt") {
@@ -66,6 +93,11 @@ class CommMsgSpec extends FunSpec with Matchers {
 
       it("should implicitly convert from a CommMsg instance to valid json") {
         Json.toJson(commMsg) should be (commMsgJson)
+      }
+
+      it("should implicitly convert a CommMsg instance with non-empty json " +
+         "data to valid json") {
+        Json.toJson(commMsgWithData) should be (commMsgJsonWithData)
       }
     }
   }

--- a/protocol/src/test/scala/com/ibm/spark/kernel/protocol/v5/content/CommOpenSpec.scala
+++ b/protocol/src/test/scala/com/ibm/spark/kernel/protocol/v5/content/CommOpenSpec.scala
@@ -19,7 +19,7 @@ package com.ibm.spark.kernel.protocol.v5.content
 import org.scalatest.{FunSpec, Matchers}
 import play.api.data.validation.ValidationError
 import play.api.libs.json._
-import com.ibm.spark.kernel.protocol.v5.Data
+import com.ibm.spark.kernel.protocol.v5.MsgData
 
 class CommOpenSpec extends FunSpec with Matchers {
   val commOpenJson: JsValue = Json.parse("""
@@ -31,7 +31,7 @@ class CommOpenSpec extends FunSpec with Matchers {
   """)
 
   val commOpen = CommOpen(
-    "<UUID>", "<STRING>", Data()
+    "<UUID>", "<STRING>", MsgData.Empty
   )
 
   describe("CommOpen") {


### PR DESCRIPTION
Fixes defect #125 by introducing the `MsgData` type, which is used to store arbitrary JSON in the `CommMsg`'s `data` field. Updates related test cases and adds two new test cases in `CommMsgSpec`.