### PR TITLE
get truncateResult to format tuples and allow newlines in the result.…

### DIFF
--- a/kernel-api/src/main/scala/com/ibm/spark/interpreter/ScalaInterpreter.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/interpreter/ScalaInterpreter.scala
@@ -202,7 +202,9 @@ class ScalaInterpreter(
   }
 
   def truncateResult(result:String, showType:Boolean =false, noTruncate: Boolean = false): String = {
-    val resultRX="""(res\d+):\s+(\S+)\s+=\s+(.*)""".r
+
+    // The (?s) allows newline characters in the string
+    val resultRX="""(?s)(res\d+):\s+(.*)\s+=\s+(.*)""".r
 
     result match {
       case resultRX(varName,varType,resString) => {

--- a/kernel-api/src/main/scala/com/ibm/spark/kernel/api/KernelOptions.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/kernel/api/KernelOptions.scala
@@ -17,6 +17,6 @@ package com.ibm.spark.kernel.api
 
 
 object KernelOptions {
-  var showTypes: Boolean = false
+  var showTypes: Boolean = true
   var noTruncation: Boolean = false
 }


### PR DESCRIPTION
Thank you so much for building this spark kernel - It's been a big hit at datastax.  I added our own spark-cassandra connector to it and we're able to create cassandra RDDs in the notebook.  I can submit a pull request for it if you'd like to incorporate it in the kernel.    We ran into an issue where certain return values were not showing up in the notebook.  It turned out the regexp in truncateResult was not matching tuples, as well as return values containing newlines.  Here is the fix for that.   This also turns on show type by default as many of our spark newbies get a bit confused about datatypes, so this is a bit more overt.