### PR TITLE
Fixed Vagrantfile to support stable 3.X jupyter and pyspark

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -63,7 +63,7 @@ object Common {
     isSnapshot := snapshot,
     sparkVersion := {
       val sparkEnvironmentVariable = "APACHE_SPARK_VERSION"
-      val defaultSparkVersion = "1.5.0"
+      val defaultSparkVersion = "1.5.1"
 
       val _sparkVersion = Properties.envOrNone(sparkEnvironmentVariable)
 


### PR DESCRIPTION
This PR will do a couple of things:
1. Upgrade master to Spark 1.5.1. Resolves #153 
2. Fix VagrantFile to install a proper package of 3.x ipython for testing
3. Fix VagrantFile to download a Spark distro at the correct version to allow pyspark to work
4. Fix VagrantFile to create the correct kernel.json to enable pyspark and some other good Env settings