### PR TITLE
Fix %AddJar parsing of JAR URL.  Don't attempt classpath reload if jar file not .jar or .zip.

### DIFF
--- a/kernel/src/test/scala/com/ibm/spark/magic/builtin/AddJarSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/magic/builtin/AddJarSpec.scala
@@ -204,10 +204,12 @@ class AddJarSpec extends FunSpec with Matchers with MockitoSugar {
           override val outputStream: OutputStream = mockOutputStream
           override lazy val magicLoader: MagicLoader = mockMagicLoader
           override val config = testConfig
+          override def downloadFile(fileUrl: URL, destinationUrl: URL): URL =
+            new URL("file://someFile") // Cannot mock URL
         }
 
         addJarMagic.execute(
-          """--magic http://www.example.com/""")
+          """--magic http://www.example.com/someJar.jar""")
 
         verify(mockMagicLoader).addJar(any())
         verify(mockSparkContext, times(0)).addJar(anyString())

--- a/kernel/src/test/scala/com/ibm/spark/magic/builtin/AddJarSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/magic/builtin/AddJarSpec.scala
@@ -64,6 +64,45 @@ class AddJarSpec extends FunSpec with Matchers with MockitoSugar {
         verify(mockMagicLoader, times(0)).addJar(any())
       }
 
+      it("should raise exception if jar file does not end in .jar or .zip") {
+        val mockOutputStream = mock[OutputStream]
+
+        val addJarMagic = new AddJar
+          with IncludeOutputStream
+        {
+          override val outputStream: OutputStream = mockOutputStream
+        }
+
+        intercept[IllegalArgumentException] {
+          addJarMagic.execute("""http://www.example.com/""")
+        }
+        intercept[IllegalArgumentException] {
+          addJarMagic.execute("""http://www.example.com/not_a_jar""")
+        }
+      }
+
+      it("should extract jar file name from jar URL") {
+        val mockOutputStream = mock[OutputStream]
+
+        val addJarMagic = new AddJar
+          with IncludeOutputStream
+        {
+          override val outputStream: OutputStream = mockOutputStream
+        }
+
+        var url = """http://www.example.com/someJar.jar"""
+        var jarName = addJarMagic.getFileFromLocation(url)
+        assert(jarName == "someJar.jar")
+
+        url = """http://www.example.com/remotecontent?filepath=/path/to/someJar.jar"""
+        jarName = addJarMagic.getFileFromLocation(url)
+        assert(jarName == "someJar.jar")
+
+        url = """http://www.example.com/"""
+        jarName = addJarMagic.getFileFromLocation(url)
+        assert(jarName == "")
+      }
+
       it("should use a cached jar if the force option is not provided") {
         val mockSparkContext = mock[SparkContext]
         val mockInterpreter = mock[Interpreter]

--- a/scala-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -154,6 +154,7 @@ class ScalaInterpreter(
     val platform = sparkIMain.global.platform.asInstanceOf[JavaPlatform]
 
     val newClassPath = mergeJarsIntoClassPath(platform, jars:_*)
+    logger.debug(s"newClassPath: ${newClassPath}")
 
     // TODO: Investigate better way to set this... one thought is to provide
     //       a classpath in the currentClassPath (which is merged) that can be


### PR DESCRIPTION
Fixes issue #181