### PR TITLE
Added imports statements via command line arguments and application.conf settings.

### DIFF
--- a/kernel-api/src/main/scala/com/ibm/spark/interpreter/ImportLoader.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/interpreter/ImportLoader.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.spark.interpreter
+
+import com.typesafe.config.Config
+
+import scala.collection.JavaConverters._
+
+object ImportLoader {
+  def loadImports(config: Config, interpreterName: String, interpreter: Interpreter) : Unit = {
+    val importConfigPath: String = s"interpreter.${interpreterName}.import"
+    if(config.hasPath(importConfigPath)) {
+      val imports: Seq[String] = config.getStringList(importConfigPath).asScala
+      interpreter.addImports(imports : _*)
+    }
+  }
+}

--- a/kernel-api/src/main/scala/com/ibm/spark/interpreter/Interpreter.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/interpreter/Interpreter.scala
@@ -115,4 +115,19 @@ trait Interpreter {
    * @return The runtime class loader used by this interpreter
    */
   def classLoader: ClassLoader
+
+  /**
+   * An interface for adding imports to the interpreter. The values parameter
+   * will be the raw values to import. For example a scala interpreter
+   * could receive a sequence of values like:
+   *  [
+   *    com.typesafe._,
+   *    org.apache.spark.SparkConf
+   *  ]    
+   *  
+   *  It would be then up to the interpreter to appropriately import those
+   *  values into the interpreter.
+   * @param values String values of the items to import
+   */
+  def addImports(values: String*): Unit
 }

--- a/kernel-api/src/test/scala/com/ibm/spark/interpreter/ImportLoaderSpec.scala
+++ b/kernel-api/src/test/scala/com/ibm/spark/interpreter/ImportLoaderSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.spark.interpreter
+
+import com.typesafe.config.{ConfigFactory, Config}
+import org.mockito.Mockito._
+import org.mockito.Matchers._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FunSpec, Matchers}
+import scala.collection.JavaConversions._
+
+class ImportLoaderSpec extends FunSpec with Matchers with MockitoSugar {
+  describe("ImportLoader") {
+    describe("#loadImports") {
+      
+      it("should load imports from config and pass them along to the interpreter"){
+        val mockConfig = mock[Config]
+        val mockInterpreter = mock[Interpreter]
+        val mockImports = Seq("foo", "bar", "baz")
+        val testPath: String = "interpreter.test.import"
+        when(mockConfig.getStringList(testPath)).thenReturn(seqAsJavaList(mockImports))
+        when(mockConfig.hasPath(testPath)).thenReturn(true)
+        ImportLoader.loadImports(mockConfig, "test", mockInterpreter)
+        verify(mockInterpreter).addImports(mockImports:_*)
+      }
+      
+      it("should not invoke the interpreter if the are no values to import") {
+        val mockInterpreter = mock[Interpreter]
+        ImportLoader.loadImports(ConfigFactory.empty(), "test", mockInterpreter)
+        verify(mockInterpreter, times(0)).addImports(anyString())
+      }
+    }
+    
+  }
+}

--- a/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
+++ b/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
@@ -174,7 +174,9 @@ trait StandardComponentInitialization extends ComponentInitialization {
 
     logger.debug("Starting interpreter")
     interpreter.start()
-
+    
+    ImportLoader.loadImports(config, "scala", interpreter)
+    
     interpreter
   }
 

--- a/kernel/src/test/scala/com/ibm/spark/boot/CommandLineOptionsSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/boot/CommandLineOptionsSpec.scala
@@ -335,6 +335,23 @@ class CommandLineOptionsSpec extends FunSpec with Matchers {
           be (Seq(url1, url2))
       }
     }
+
+
+    describe("when received --interpreter-scala-imports=<value>") {
+      describe("#toConfig") {
+        it("should set create a list of valus for an interpreter") {
+          val expected = "my.test.package.MyClass"
+          val expected2 = "my.test.package.MyClass2"
+          val options = new CommandLineOptions(
+            s"--interpreter-scala-import=${expected}" ::
+            s"--interpreter-scala-import=${expected2}" :: Nil)
+          val config: Config = options.toConfig
+
+          config.getStringList("interpreter.scala.import") should 
+            contain only(expected, expected2)
+        }
+      }
+    }
   }
 
 }

--- a/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkInterpreter.scala
+++ b/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkInterpreter.scala
@@ -20,8 +20,8 @@ import java.net.URL
 import com.ibm.spark.interpreter.Results.Result
 import com.ibm.spark.interpreter._
 import com.ibm.spark.kernel.api.KernelLike
+import com.ibm.spark.utils.LogLike
 import org.apache.spark.SparkContext
-import org.slf4j.LoggerFactory
 import py4j.GatewayServer
 
 import scala.concurrent.Await
@@ -39,8 +39,7 @@ import scala.tools.nsc.interpreter.{InputStream, OutputStream}
 class PySparkInterpreter(
   private val _kernel: KernelLike,
   private val _sparkContext: SparkContext
-) extends Interpreter {
-  private val logger = LoggerFactory.getLogger(this.getClass)
+) extends Interpreter with LogLike {
 
   // TODO: Replace hard-coded maximum queue count
   /** Represents the state used by this interpreter's Python instance. */
@@ -144,4 +143,13 @@ class PySparkInterpreter(
 
   // Unsupported
   override def doQuietly[T](body: => T): T = ???
+
+  override def addImports(values: String*): Unit = {
+    logger.warn(
+      s"""Imports are not yet supported by the PySpark interpreter.
+         |Skipping imports for:
+         |${values.reduce(_+"\n"+_)}|
+       """.stripMargin
+    )
+  }
 }

--- a/scala-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -498,5 +498,9 @@ class ScalaInterpreter(
   }
 
   override def classLoader: ClassLoader = _runtimeClassloader
+
+  override def addImports(values: String*): Unit = {
+    sparkIMain.addImports(values:_*)
+  }
 }
 

--- a/sparkr-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sparkr/SparkRInterpreter.scala
+++ b/sparkr-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sparkr/SparkRInterpreter.scala
@@ -143,4 +143,12 @@ class SparkRInterpreter(
 
   // Unsupported
   override def doQuietly[T](body: => T): T = ???
+  override def addImports(values: String*): Unit = {
+    logger.warn(
+      s"""Imports are not yet supported by the SparkR interpreter.
+         |Skipping imports for:
+         |${values.reduce(_+"\n"+_)}|
+       """.stripMargin
+    )
+  }
 }

--- a/sql-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sql/SqlInterpreter.scala
+++ b/sql-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sql/SqlInterpreter.scala
@@ -19,6 +19,7 @@ import java.net.URL
 
 import com.ibm.spark.interpreter.{ExecuteFailure, ExecuteOutput, Interpreter}
 import com.ibm.spark.interpreter.Results.Result
+import com.ibm.spark.utils.LogLike
 import org.apache.spark.sql.SQLContext
 
 import scala.concurrent.duration._
@@ -28,7 +29,8 @@ import scala.tools.nsc.interpreter.{OutputStream, InputStream}
 /**
  * Represents an interpreter interface to Spark SQL.
  */
-class SqlInterpreter(private val sqlContext: SQLContext) extends Interpreter {
+class SqlInterpreter(private val sqlContext: SQLContext) extends Interpreter 
+  with LogLike {
   private lazy val sqlService = new SqlService(sqlContext)
   private lazy val sqlTransformer = new SqlTransformer
 
@@ -105,4 +107,13 @@ class SqlInterpreter(private val sqlContext: SQLContext) extends Interpreter {
 
   // Unsupported
   override def doQuietly[T](body: => T): T = ???
+
+  override def addImports(values: String*): Unit = {
+    logger.warn(
+      s"""Imports are not yet supported by the SQL interpreter.
+         |Skipping imports for:
+         |${values.reduce(_+"\n"+_)}|
+       """.stripMargin
+    )
+  }
 }


### PR DESCRIPTION
These changes allow for specifying imports via command line options or A *.conf file.

### Command Line Options
```
sparkkernel --interpreter-scala-import=org.codehaus.jackson.Base64Variant --interpreter-scala-import=org,apache.spark._
```

### Application/Reference Conf
```
interpreter.scala.import = [
   org.codehaus.jackson.Base64Variant,
   org,apache.spark._
]
```


You currently can specify imports for all interpreters, but only the scala ones are used. 