### PR TITLE
Command line option to turn off auto creation of Sparkcontext

### DIFF
--- a/kernel-api/src/main/scala/com/ibm/spark/interpreter/broker/BrokerBridge.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/interpreter/broker/BrokerBridge.scala
@@ -28,37 +28,19 @@ import org.apache.spark.{SparkConf, SparkContext}
  *
  * @param _brokerState The container of broker state to expose
  * @param _kernel The kernel API to expose through the bridge
- * @param _sparkContext The SparkContext to expose through the bridge
  */
 class BrokerBridge(
   private val _brokerState: BrokerState,
-  private val _kernel: KernelLike,
-  private val _sparkContext: SparkContext
+  private val _kernel: KernelLike
 ) extends BrokerName {
-  this: JavaSparkContextProducerLike with SQLContextProducerLike =>
   /**
    * Represents the current state of the broker.
    */
   val state: BrokerState = _brokerState
 
   /**
-   * Represents the context used as one of the main entrypoints into Spark.
-   */
-  val javaSparkContext: JavaSparkContext = newJavaSparkContext(_sparkContext)
-
-  /**
-   * Represents the context used as the SQL entrypoint into Spark.
-   */
-  val sqlContext: SQLContext = newSQLContext(_sparkContext)
-
-  /**
    * Represents the kernel API available.
    */
   val kernel: KernelLike = _kernel
-
-  /**
-   * Represents the configuration containing the current SparkContext setup.
-   */
-  val sparkConf: SparkConf = _sparkContext.getConf
 }
 

--- a/kernel-api/src/main/scala/com/ibm/spark/kernel/api/KernelLike.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/kernel/api/KernelLike.scala
@@ -18,10 +18,18 @@ package com.ibm.spark.kernel.api
 
 import java.io.{PrintStream, InputStream, OutputStream}
 
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SQLContext
+
 /**
  * Interface for the kernel API. This does not include exposed variables.
  */
 trait KernelLike {
+
+  def createSparkContext(conf: SparkConf): SparkContext
+
+  def createSparkContext(master: String, appName: String): SparkContext
+
   /**
    * Executes a block of code represented as a string and returns the result.
    *
@@ -80,4 +88,8 @@ trait KernelLike {
    * @note Using Java structure to enable other languages to have easy access!
    */
   val data: java.util.Map[String, Any]
+
+  def sparkContext: SparkContext
+
+  def sqlContext: SQLContext
 }

--- a/kernel-api/src/main/scala/com/ibm/spark/kernel/api/KernelLike.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/kernel/api/KernelLike.scala
@@ -18,6 +18,7 @@ package com.ibm.spark.kernel.api
 
 import java.io.{PrintStream, InputStream, OutputStream}
 
+import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.SQLContext
 
@@ -90,6 +91,10 @@ trait KernelLike {
   val data: java.util.Map[String, Any]
 
   def sparkContext: SparkContext
+
+  def sparkConf: SparkConf
+
+  def javaSparkContext: JavaSparkContext
 
   def sqlContext: SQLContext
 }

--- a/kernel-api/src/main/scala/com/ibm/spark/magic/MagicLoader.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/magic/MagicLoader.scala
@@ -25,7 +25,7 @@ import scala.reflect.runtime.{universe => runtimeUniverse}
 import scala.collection.JavaConversions._
 
 class MagicLoader(
-  val dependencyMap: DependencyMap = new DependencyMap(),
+  var dependencyMap: DependencyMap = new DependencyMap(),
   urls: Array[URL] = Array(),
   parentLoader: ClassLoader = null
 ) extends URLClassLoader(urls, parentLoader) {

--- a/kernel-api/src/test/scala/com/ibm/spark/interpreter/broker/BrokerBridgeSpec.scala
+++ b/kernel-api/src/test/scala/com/ibm/spark/interpreter/broker/BrokerBridgeSpec.scala
@@ -29,26 +29,11 @@ class BrokerBridgeSpec extends FunSpec with Matchers with OneInstancePerTest
 {
   private val mockBrokerState = mock[BrokerState]
   private val mockKernel = mock[KernelLike]
-  private val mockSparkConf = mock[SparkConf]
-  private val mockSparkContext = mock[SparkContext]
-
-  private val mockJavaSparkContext = mock[JavaSparkContext]
-  doReturn(mockSparkContext).when(mockJavaSparkContext).sc
-  private val mockSqlContext = mock[SQLContext]
-  doReturn(mockSparkContext).when(mockSqlContext).sparkContext
-
-  // A new SQLContext is created per request, meaning this needs mocking
-  doReturn(mockSparkConf).when(mockSparkContext).getConf
-  doReturn(Array[(String, String)]()).when(mockSparkConf).getAll
 
   private val brokerBridge = new BrokerBridge(
     mockBrokerState,
-    mockKernel,
-    mockSparkContext
-  ) with JavaSparkContextProducerLike with SQLContextProducerLike {
-    override def newJavaSparkContext(sparkContext: SparkContext): JavaSparkContext = mockJavaSparkContext
-    override def newSQLContext(sparkContext: SparkContext): SQLContext = mockSqlContext
-  }
+    mockKernel
+  )
 
   describe("BrokerBridge") {
     describe("#state") {
@@ -57,27 +42,9 @@ class BrokerBridgeSpec extends FunSpec with Matchers with OneInstancePerTest
       }
     }
 
-    describe("#javaSparkContext") {
-      it("should return a JavaSparkContext wrapping the SparkContext") {
-        brokerBridge.javaSparkContext.sc should be (mockSparkContext)
-      }
-    }
-
-    describe("#sqlContext") {
-      it("should return a SQLContext wrapping the SparkContext") {
-        brokerBridge.sqlContext.sparkContext should be (mockSparkContext)
-      }
-    }
-
     describe("#kernel") {
       it("should return the kernel from the constructor") {
         brokerBridge.kernel should be (mockKernel)
-      }
-    }
-
-    describe("#sparkConf") {
-      it("should return the configuration from the SparkContext") {
-        brokerBridge.sparkConf should be (mockSparkConf)
       }
     }
   }

--- a/kernel/src/main/scala/com/ibm/spark/boot/CommandLineOptions.scala
+++ b/kernel/src/main/scala/com/ibm/spark/boot/CommandLineOptions.scala
@@ -93,6 +93,10 @@ class CommandLineOptions(args: Seq[String]) {
     parser.accepts("default-interpreter", "default interpreter for the kernel")
       .withRequiredArg().ofType(classOf[String])
 
+  private val _sparkcontext =
+    parser.accepts("sparkcontext", "should kernel create a spark context")
+      .withRequiredArg().ofType(classOf[String])
+
   private val options = parser.parse(args.map(_.trim): _*)
 
   /*
@@ -147,7 +151,8 @@ class CommandLineOptions(args: Seq[String]) {
         .flatMap(str => if (str.nonEmpty) Some(str) else None),
       "max_interpreter_threads" -> get(_max_interpreter_threads),
       "jar_dir" -> get(_jar_dir),
-      "default_interpreter" -> get(_default_interpreter)
+      "default_interpreter" -> get(_default_interpreter),
+      "sparkcontext" -> get(_sparkcontext)
     ).flatMap(removeEmptyOptions).asInstanceOf[Map[String, AnyRef]].asJava)
 
     commandLineConfig.withFallback(profileConfig).withFallback(ConfigFactory.load)

--- a/kernel/src/main/scala/com/ibm/spark/boot/CommandLineOptions.scala
+++ b/kernel/src/main/scala/com/ibm/spark/boot/CommandLineOptions.scala
@@ -93,9 +93,9 @@ class CommandLineOptions(args: Seq[String]) {
     parser.accepts("default-interpreter", "default interpreter for the kernel")
       .withRequiredArg().ofType(classOf[String])
 
-  private val _sparkcontext =
-    parser.accepts("sparkcontext", "should kernel create a spark context")
-      .withRequiredArg().ofType(classOf[String])
+  private val _nosparkcontext =
+    parser.accepts("nosparkcontext", "kernel should not create a spark context")
+
 
   private val options = parser.parse(args.map(_.trim): _*)
 
@@ -152,7 +152,7 @@ class CommandLineOptions(args: Seq[String]) {
       "max_interpreter_threads" -> get(_max_interpreter_threads),
       "jar_dir" -> get(_jar_dir),
       "default_interpreter" -> get(_default_interpreter),
-      "sparkcontext" -> get(_sparkcontext)
+      "nosparkcontext" -> (if (has(_nosparkcontext)) Some(true) else Some(false))
     ).flatMap(removeEmptyOptions).asInstanceOf[Map[String, AnyRef]].asJava)
 
     commandLineConfig.withFallback(profileConfig).withFallback(ConfigFactory.load)

--- a/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
+++ b/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
@@ -142,7 +142,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
   }
 
   def initializeSparkContext(config:Config, kernel:Kernel, appName:String) = {
-    if(config.getString("sparkcontext") != "no") {
+    if(!config.getBoolean("nosparkcontext")) {
       kernel.createSparkContext(config.getString("spark.master"), appName)
     }
   }

--- a/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
+++ b/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
@@ -81,6 +81,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
     val (commStorage, commRegistrar, commManager) =
       initializeCommObjects(actorLoader)
     val interpreter = initializeInterpreter(config)
+
     //val sparkContext = null
     //val sparkContext = initializeSparkContext(
     //  config, appName, actorLoader, interpreter)
@@ -133,8 +134,13 @@ trait StandardComponentInitialization extends ComponentInitialization {
           interpreter
       }
 
+    if(config.getString("sparkcontext") != "no") {
+      kernel.createSparkContext(config.getString("spark.master"), appName)
+    }
+
     (commStorage, commRegistrar, commManager, defaultInterpreter, kernel,
       dependencyDownloader, magicLoader, responseMap)
+
   }
 
   private def initializeCommObjects(actorLoader: ActorLoader) = {

--- a/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
+++ b/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
@@ -134,13 +134,17 @@ trait StandardComponentInitialization extends ComponentInitialization {
           interpreter
       }
 
-    if(config.getString("sparkcontext") != "no") {
-      kernel.createSparkContext(config.getString("spark.master"), appName)
-    }
+    initializeSparkContext(config, kernel, appName)
 
     (commStorage, commRegistrar, commManager, defaultInterpreter, kernel,
       dependencyDownloader, magicLoader, responseMap)
 
+  }
+
+  def initializeSparkContext(config:Config, kernel:Kernel, appName:String) = {
+    if(config.getString("sparkcontext") != "no") {
+      kernel.createSparkContext(config.getString("spark.master"), appName)
+    }
   }
 
   private def initializeCommObjects(actorLoader: ActorLoader) = {

--- a/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
+++ b/kernel/src/main/scala/com/ibm/spark/boot/layer/ComponentInitialization.scala
@@ -58,7 +58,7 @@ trait ComponentInitialization {
   def initializeComponents(
     config: Config, appName: String, actorLoader: ActorLoader
   ): (CommStorage, CommRegistrar, CommManager, Interpreter,
-    Kernel, SparkContext, DependencyDownloader, MagicLoader,
+    Kernel, DependencyDownloader, MagicLoader,
     collection.mutable.Map[String, ActorRef])
 }
 
@@ -81,14 +81,16 @@ trait StandardComponentInitialization extends ComponentInitialization {
     val (commStorage, commRegistrar, commManager) =
       initializeCommObjects(actorLoader)
     val interpreter = initializeInterpreter(config)
-    val sparkContext = initializeSparkContext(
-      config, appName, actorLoader, interpreter)
-    val sqlContext = initializeSqlContext(sparkContext)
-    updateInterpreterWithSqlContext(sqlContext, interpreter)
+    //val sparkContext = null
+    //val sparkContext = initializeSparkContext(
+    //  config, appName, actorLoader, interpreter)
+    //val sqlContext = null
+    //val sqlContext = initializeSqlContext(sparkContext)
+    //updateInterpreterWithSqlContext(sqlContext, interpreter)
 
     val dependencyDownloader = initializeDependencyDownloader(config)
     val magicLoader = initializeMagicLoader(
-      config, interpreter, sparkContext, dependencyDownloader)
+      config, interpreter, dependencyDownloader)
     val kernel = initializeKernel(
       config, actorLoader, interpreter, commManager, magicLoader
     )
@@ -96,17 +98,17 @@ trait StandardComponentInitialization extends ComponentInitialization {
 
     // NOTE: Tested via initializing the following and returning this
     //       interpreter instead of the Scala one
-    val pySparkInterpreter = new PySparkInterpreter(kernel, sparkContext)
+    val pySparkInterpreter = new PySparkInterpreter(kernel)
     //pySparkInterpreter.start()
     kernel.data.put("PySpark", pySparkInterpreter)
 
     // NOTE: Tested via initializing the following and returning this
     //       interpreter instead of the Scala one
-    val sparkRInterpreter = new SparkRInterpreter(kernel, sparkContext)
+    val sparkRInterpreter = new SparkRInterpreter(kernel)
     //sparkRInterpreter.start()
     kernel.data.put("SparkR", sparkRInterpreter)
 
-    val sqlInterpreter = new SqlInterpreter(sqlContext)
+    val sqlInterpreter = new SqlInterpreter(kernel)
     //sqlInterpreter.start()
     kernel.data.put("SQL", sqlInterpreter)
 
@@ -132,7 +134,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
       }
 
     (commStorage, commRegistrar, commManager, defaultInterpreter, kernel,
-      sparkContext, dependencyDownloader, magicLoader, responseMap)
+      dependencyDownloader, magicLoader, responseMap)
   }
 
   private def initializeCommObjects(actorLoader: ActorLoader) = {
@@ -179,6 +181,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
   }
 
   // TODO: Think of a better way to test without exposing this
+  /*
   protected[layer] def initializeSparkContext(
     config: Config, appName: String, actorLoader: ActorLoader,
     interpreter: Interpreter
@@ -319,6 +322,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
       logger.info("Running in local mode! Not adding self as dependency!")
     }
   }
+  */
 
   protected[layer] def initializeSqlContext(sparkContext: SparkContext) = {
     val sqlContext: SQLContext = try {
@@ -394,7 +398,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
   }
 
   private def initializeMagicLoader(
-    config: Config, interpreter: Interpreter, sparkContext: SparkContext,
+    config: Config, interpreter: Interpreter,
     dependencyDownloader: DependencyDownloader
   ) = {
     logger.debug("Constructing magic loader")
@@ -403,7 +407,6 @@ trait StandardComponentInitialization extends ComponentInitialization {
     val dependencyMap = new DependencyMap()
       .setInterpreter(interpreter)
       .setKernelInterpreter(interpreter) // This is deprecated
-      .setSparkContext(sparkContext)
       .setDependencyDownloader(dependencyDownloader)
       .setConfig(config)
 

--- a/kernel/src/main/scala/com/ibm/spark/kernel/api/Kernel.scala
+++ b/kernel/src/main/scala/com/ibm/spark/kernel/api/Kernel.scala
@@ -28,11 +28,13 @@ import com.ibm.spark.kernel.protocol.v5
 import com.ibm.spark.kernel.protocol.v5.{KMBuilder, KernelMessage}
 import com.ibm.spark.kernel.protocol.v5.kernel.ActorLoader
 import com.ibm.spark.kernel.protocol.v5.magic.MagicParser
-import com.ibm.spark.kernel.protocol.v5.stream.KernelInputStream
+import com.ibm.spark.kernel.protocol.v5.stream.{KernelOutputStream, KernelInputStream}
 import com.ibm.spark.magic.{MagicLoader, MagicExecutor}
-import com.ibm.spark.utils.LogLike
+import com.ibm.spark.utils.{KeyValuePairUtils, LogLike}
 import com.typesafe.config.Config
-import scala.util.DynamicVariable
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.{SparkContext, SparkConf}
+import scala.util.{Try, DynamicVariable}
 
 import scala.reflect.runtime.universe._
 
@@ -81,6 +83,9 @@ class Kernel (
     new DynamicVariable[PrintStream](null)
   private val currentErrorKernelMessage =
     new DynamicVariable[KernelMessage](null)
+
+  private var _sparkContext:SparkContext = null;
+  private var _sqlContext:SQLContext = null;
 
   /**
    * Represents magics available through the kernel.
@@ -305,4 +310,150 @@ class Kernel (
     require(someKernelMessage.nonEmpty, "No kernel message received!")
     someKernelMessage.get
   }
+
+  override def createSparkContext(conf: SparkConf): SparkContext = {
+    _sparkContext = initializeSparkContext(conf)
+    _sqlContext = new SQLContext(_sparkContext)
+
+    magicLoader.dependencyMap =
+      magicLoader.dependencyMap.setSparkContext(_sparkContext)
+
+    _sparkContext
+  }
+
+  override def createSparkContext(
+    master: String, appName: String
+  ): SparkContext = {
+    createSparkContext(new SparkConf().setMaster(master).setAppName(appName))
+  }
+
+  // TODO: Think of a better way to test without exposing this
+  private def initializeSparkContext(conf: SparkConf) = {
+
+    logger.info("Setting deployMode to client")
+    conf.set("spark.submit.deployMode", "client")
+
+    KeyValuePairUtils.stringToKeyValuePairSeq(
+      config.getString("spark_configuration")
+    ).foreach { keyValuePair =>
+      logger.info(s"Setting ${keyValuePair.key} to ${keyValuePair.value}")
+      Try(conf.set(keyValuePair.key, keyValuePair.value))
+    }
+
+    // TODO: Move SparkIMain to private and insert in a different way
+    logger.warn("Locked to Scala interpreter with SparkIMain until decoupled!")
+
+    // TODO: Construct class server outside of SparkIMain
+    logger.warn("Unable to control initialization of REPL class server!")
+    logger.info("REPL Class Server Uri: " + interpreter.classServerURI)
+    conf.set("spark.repl.class.uri", interpreter.classServerURI)
+
+    val sparkContext = reallyInitializeSparkContext(conf);
+
+    updateInterpreterWithSparkContext(sparkContext)
+
+    sparkContext
+  }
+
+  // TODO: Think of a better way to test without exposing this
+  private def reallyInitializeSparkContext(sparkConf: SparkConf): SparkContext = {
+
+    logger.debug("Constructing new Spark Context")
+    // TODO: Inject stream redirect headers in Spark dynamically
+    var sparkContext: SparkContext = null
+    val outStream = new KernelOutputStream(
+      actorLoader, KMBuilder(), global.ScheduledTaskManager.instance,
+      sendEmptyOutput = config.getBoolean("send_empty_output")
+    )
+
+    // Update global stream state and use it to set the Console local variables
+    // for threads in the Spark threadpool
+    global.StreamState.setStreams(System.in, outStream, outStream)
+    global.StreamState.withStreams {
+      sparkContext = new SparkContext(sparkConf)
+    }
+
+    sparkContext
+  }
+
+  // TODO: Think of a better way to test without exposing this
+  private def updateInterpreterWithSparkContext(
+    sparkContext: SparkContext
+  ) = {
+    interpreter.doQuietly {
+      logger.debug("Binding context into interpreter")
+      interpreter.bind(
+        "sc", "org.apache.spark.SparkContext",
+        sparkContext, List( """@transient"""))
+
+      // NOTE: This is needed because interpreter blows up after adding
+      //       dependencies to SparkContext and Interpreter before the
+      //       cluster has been used... not exactly sure why this is the case
+      // TODO: Investigate why the cluster has to be initialized in the kernel
+      //       to avoid the kernel's interpreter blowing up (must be done
+      //       inside the interpreter)
+      logger.debug("Initializing Spark cluster in interpreter")
+
+      interpreter.doQuietly {
+        interpreter.interpret("""
+                                | val $toBeNulled = {
+                                | var $toBeNulled = sc.emptyRDD.collect()
+                                | $toBeNulled = null
+                                |  }
+                                |
+                                |""".stripMargin)
+      }
+    }
+
+    // Add ourselves as a dependency
+    // TODO: Provide ability to point to library as commandline argument
+    // TODO: Provide better method to determine if can add ourselves
+    // TODO: Avoid duplicating request for master twice (initializeSparkContext
+    //       also does this)
+    val master = sparkContext.getConf.get("spark.master")
+
+    // If in local mode, do not need to add our jars as dependencies
+    if (!master.toLowerCase.startsWith("local")) {
+      @inline def getJarPathFor(klass: Class[_]): String =
+        klass.getProtectionDomain.getCodeSource.getLocation.getPath
+
+      // TODO: Provide less hard-coded solution in case additional dependencies
+      //       are added or classes are refactored to different projects
+      val jarPaths = Seq(
+        // Macro project
+        classOf[com.ibm.spark.annotations.Experimental],
+
+        // Protocol project
+        classOf[com.ibm.spark.kernel.protocol.v5.KernelMessage],
+
+        // Communication project
+        classOf[com.ibm.spark.communication.SocketManager],
+
+        // Kernel-api project
+        classOf[com.ibm.spark.kernel.api.KernelLike],
+
+        // Scala-interpreter project
+        classOf[com.ibm.spark.kernel.interpreter.scala.ScalaInterpreter],
+
+        // PySpark-interpreter project
+        classOf[com.ibm.spark.kernel.interpreter.pyspark.PySparkInterpreter],
+
+        // SparkR-interpreter project
+        classOf[com.ibm.spark.kernel.interpreter.sparkr.SparkRInterpreter],
+
+        // Kernel project
+        classOf[com.ibm.spark.boot.KernelBootstrap]
+      ).map(getJarPathFor)
+
+      logger.info("Adding kernel jars to cluster:\n- " +
+        jarPaths.mkString("\n- "))
+      jarPaths.foreach(sparkContext.addJar)
+    } else {
+      logger.info("Running in local mode! Not adding self as dependency!")
+    }
+  }
+
+  override def sparkContext: SparkContext = _sparkContext
+
+  override def sqlContext: SQLContext = _sqlContext
 }

--- a/kernel/src/test/scala/com/ibm/spark/boot/layer/StandardComponentInitializationSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/boot/layer/StandardComponentInitializationSpec.scala
@@ -52,6 +52,7 @@ class StandardComponentInitializationSpec extends FunSpec with Matchers
     spyComponentInitialization = spy(new TestComponentInitialization())
   }
 
+  /*
   describe("StandardComponentInitialization") {
     describe("when spark.master is set in config") {
       it("should set spark.master in SparkConf") {
@@ -109,4 +110,5 @@ class StandardComponentInitializationSpec extends FunSpec with Matchers
       }
     }
   }
+  */
 }

--- a/kernel/src/test/scala/integration/InterpreterActorSpecForIntegration.scala
+++ b/kernel/src/test/scala/integration/InterpreterActorSpecForIntegration.scala
@@ -71,10 +71,10 @@ class InterpreterActorSpecForIntegration extends TestKit(
     interpreter.doQuietly({
       conf.set("spark.repl.class.uri", interpreter.classServerURI)
       //context = new SparkContext(conf) with NoSparkLogging
-      context = SparkContextProvider.sparkContext
-      interpreter.bind(
-        "sc", "org.apache.spark.SparkContext",
-        context, List( """@transient"""))
+      //context = SparkContextProvider.sparkContext
+      //interpreter.bind(
+      //  "sc", "org.apache.spark.SparkContext",
+      //  context, List( """@transient"""))
     })
   }
 

--- a/kernel/src/test/scala/test/utils/SparkKernelDeployer.scala
+++ b/kernel/src/test/scala/test/utils/SparkKernelDeployer.scala
@@ -21,6 +21,7 @@ import java.io.OutputStream
 import akka.actor.{Actor, Props, ActorRef, ActorSystem}
 import akka.testkit.TestProbe
 import com.ibm.spark.boot.{CommandLineOptions, KernelBootstrap}
+import com.ibm.spark.kernel.api.KernelLike
 import com.ibm.spark.kernel.interpreter.scala.{StandardTaskManagerProducer, StandardSparkIMainProducer, StandardSettingsProducer, ScalaInterpreter}
 import com.ibm.spark.kernel.protocol.v5.{KMBuilder, SocketType}
 import com.ibm.spark.kernel.protocol.v5.kernel.ActorLoader
@@ -81,7 +82,9 @@ object SparkKernelDeployer extends LogLike with MockitoSugar {
       interpreter
     }
 
-    override protected[layer] def reallyInitializeSparkContext(
+
+    /*
+    def reallyInitializeSparkContext(
       config: Config,
       actorLoader: ActorLoader,
       kmBuilder: KMBuilder,
@@ -99,6 +102,7 @@ object SparkKernelDeployer extends LogLike with MockitoSugar {
 
       sparkContext
      }
+     */
 
   }
 

--- a/pyspark-interpreter/src/main/resources/PySpark/pyspark_runner.py
+++ b/pyspark-interpreter/src/main/resources/PySpark/pyspark_runner.py
@@ -51,7 +51,7 @@ bridge = gateway.entry_point
 state = bridge.state()
 state.markReady()
 
-jsc = bridge.javaSparkContext()
+#jsc = bridge.javaSparkContext()
 
 if sparkVersion.startswith("1.2"):
   java_import(gateway.jvm, "org.apache.spark.sql.SQLContext")
@@ -67,11 +67,11 @@ elif sparkVersion.startswith("1.4"):
 
 java_import(gateway.jvm, "scala.Tuple2")
 
-jconf = bridge.sparkConf()
-conf = SparkConf(_jvm = gateway.jvm, _jconf = jconf)
-sc = SparkContext(jsc = jsc, gateway = gateway, conf = conf)
-sqlc = SQLContext(sc, bridge.sqlContext())
-sqlContext = sqlc
+#jconf = bridge.sparkConf()
+#conf = SparkConf(_jvm = gateway.jvm, _jconf = jconf)
+#sc = SparkContext(jsc = jsc, gateway = gateway, conf = conf)
+#sqlc = SQLContext(sc, bridge.sqlContext())
+#sqlContext = sqlc
 kernel = bridge.kernel()
 
 class Logger(object):

--- a/pyspark-interpreter/src/main/resources/PySpark/pyspark_runner.py
+++ b/pyspark-interpreter/src/main/resources/PySpark/pyspark_runner.py
@@ -67,6 +67,9 @@ elif sparkVersion.startswith("1.4"):
 
 java_import(gateway.jvm, "scala.Tuple2")
 
+
+sc = None
+
 #jconf = bridge.sparkConf()
 #conf = SparkConf(_jvm = gateway.jvm, _jconf = jconf)
 #sc = SparkContext(jsc = jsc, gateway = gateway, conf = conf)
@@ -116,6 +119,13 @@ while True :
         final_code += "\n" + s
       else:
         final_code = s
+
+    if sc is None:
+      jsc = kernel.javaSparkContext()
+      if jsc != None:
+        jconf = kernel.sparkConf()
+        conf = SparkConf(_jvm = gateway.jvm, _jconf = jconf)
+        sc = SparkContext(jsc = jsc, gateway = gateway, conf = conf)
 
     if final_code:
       compiled_code = compile(final_code, "<string>", "exec")

--- a/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkBridge.scala
+++ b/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkBridge.scala
@@ -32,19 +32,16 @@ object PySparkBridge {
    *
    * @param brokerState The container of broker state to expose
    * @param kernel The kernel API to expose through the bridge
-   * @param sparkContext The SparkContext to expose through the bridge
    *
    * @return The new PySpark bridge
    */
   def apply(
     brokerState: BrokerState,
-    kernel: KernelLike,
-    sparkContext: SparkContext
+    kernel: KernelLike
   ): PySparkBridge = {
     new PySparkBridge(
       _brokerState = brokerState,
-      _kernel = kernel,
-      _sparkContext = sparkContext
+      _kernel = kernel
     ) with StandardJavaSparkContextProducer with StandardSQLContextProducer
   }
 }
@@ -55,14 +52,10 @@ object PySparkBridge {
  *
  * @param _brokerState The container of broker state to expose
  * @param _kernel The kernel API to expose through the bridge
- * @param _sparkContext The SparkContext to expose through the bridge
  */
 class PySparkBridge private (
   private val _brokerState: BrokerState,
-  private val _kernel: KernelLike,
-  private val _sparkContext: SparkContext
-) extends BrokerBridge(_brokerState, _kernel, _sparkContext) {
-  this: JavaSparkContextProducerLike with SQLContextProducerLike =>
-
+  private val _kernel: KernelLike
+) extends BrokerBridge(_brokerState, _kernel) {
   override val brokerName: String = "PySpark"
 }

--- a/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkInterpreter.scala
+++ b/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkInterpreter.scala
@@ -34,11 +34,9 @@ import scala.tools.nsc.interpreter.{InputStream, OutputStream}
  * where it is accessible to the Spark Kernel.
  *
  * @param _kernel The kernel API to expose to the PySpark instance
- * @param _sparkContext The Spark context to expose to the PySpark instance
  */
 class PySparkInterpreter(
-  private val _kernel: KernelLike,
-  private val _sparkContext: SparkContext
+  private val _kernel: KernelLike
 ) extends Interpreter {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -49,8 +47,7 @@ class PySparkInterpreter(
   /** Represents the bridge used by this interpreter's Python interface. */
   private lazy val pySparkBridge = PySparkBridge(
     pySparkState,
-    _kernel,
-    _sparkContext
+    _kernel
   )
 
   /** Represents the interface for Python to talk to JVM Spark components. */

--- a/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkProcess.scala
+++ b/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkProcess.scala
@@ -21,6 +21,7 @@ import com.ibm.spark.interpreter.broker.BrokerProcess
 import org.apache.commons.exec.environment.EnvironmentUtils
 import org.apache.commons.exec._
 import org.apache.commons.io.IOUtils
+import org.apache.spark.SparkContext
 import org.slf4j.LoggerFactory
 
 /**
@@ -47,6 +48,7 @@ class PySparkProcess(
   brokerProcessHandler = pySparkProcessHandler,
   arguments = Seq(port.toString, sparkVersion)
 ) {
+
   override val brokerName: String = "PySpark"
   private val logger = LoggerFactory.getLogger(this.getClass)
 

--- a/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkService.scala
+++ b/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkService.scala
@@ -17,6 +17,7 @@ package com.ibm.spark.kernel.interpreter.pyspark
 
 import com.ibm.spark.interpreter.broker.BrokerService
 import com.ibm.spark.kernel.interpreter.pyspark.PySparkTypes._
+import org.apache.spark.SparkContext
 import org.slf4j.LoggerFactory
 import py4j.GatewayServer
 
@@ -42,13 +43,14 @@ class PySparkService(
   @volatile private var _isRunning: Boolean = false
   override def isRunning: Boolean = _isRunning
 
+
   /** Represents the process used to execute Python code via the bridge. */
   private lazy val pySparkProcess = {
     val p = new PySparkProcess(
       pySparkBridge,
       pySparkProcessHandler,
       gatewayServer.getListeningPort,
-      pySparkBridge.javaSparkContext.version
+      org.apache.spark.SPARK_VERSION
     )
 
     // Update handlers to correctly reset and restart the process

--- a/resources/compile/reference.conf
+++ b/resources/compile/reference.conf
@@ -60,3 +60,5 @@ jar_dir = ${?JAR_DIR}
 default_interpreter = "scala"
 default_interpreter = ${?DEFAULT_INTERPRETER}
 
+sparkcontext = "yes"
+

--- a/scala-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -21,11 +21,14 @@ import java.net.{URL, URLClassLoader}
 import java.nio.charset.Charset
 import java.util.concurrent.ExecutionException
 
+import akka.actor.Actor
+import akka.actor.Actor.Receive
 import com.ibm.spark.global.StreamState
 import com.ibm.spark.interpreter._
 import com.ibm.spark.interpreter.imports.printers.{WrapperConsole, WrapperSystem}
 import com.ibm.spark.kernel.api.KernelOptions
 import com.ibm.spark.utils.{MultiOutputStream, TaskManager}
+import org.apache.spark.SparkContext
 import org.apache.spark.repl.{SparkIMain, SparkJLineCompletion}
 import org.slf4j.LoggerFactory
 

--- a/sparkr-interpreter/src/main/resources/kernelR/sparkr_runner.R
+++ b/sparkr-interpreter/src/main/resources/kernelR/sparkr_runner.R
@@ -58,12 +58,14 @@ kernel <- callJMethod(bridge, "kernel")
 assign("kernel", kernel, .runnerEnv)
 
 # Acquire the SparkContext instance to expose
-sc <- callJMethod(bridge, "javaSparkContext")
-assign("sc", sc, .runnerEnv)
+#sc <- callJMethod(bridge, "javaSparkContext")
+#assign("sc", sc, .runnerEnv)
+sc = NULL
 
 # Acquire the SQLContext instance to expose
-sqlContext <- callJMethod(bridge, "sqlContext")
-assign("sqlContext", sqlContext, .runnerEnv)
+#sqlContext <- callJMethod(bridge, "sqlContext")
+#sqlContext <- callJMethod(kernel, "sqlContext")
+#assign("sqlContext", sqlContext, .runnerEnv)
 
 # TODO: Is there a way to control input/output (maybe use sink)
 repeat {
@@ -80,6 +82,14 @@ repeat {
   codeId <- callJMethod(codeContainer, "codeId")
   code <- callJMethod(codeContainer, "code")
 
+  if (is.null(sc)) {
+    sc <- callJMethod(kernel, "javaSparkContext")
+    if(!is.null(sc) {
+      assign("sc", sc, .runnerEnv)
+      sqlContext <- callJMethod(kernel, "sqlContext")
+      assign("sqlContext", sqlContext, .runnerEnv)
+    }
+  }
   print(paste("Received Id", codeId, "Code", code))
 
   # Parse the code into an expression to be evaluated

--- a/sparkr-interpreter/src/main/resources/kernelR/sparkr_runner.R
+++ b/sparkr-interpreter/src/main/resources/kernelR/sparkr_runner.R
@@ -60,7 +60,7 @@ assign("kernel", kernel, .runnerEnv)
 # Acquire the SparkContext instance to expose
 #sc <- callJMethod(bridge, "javaSparkContext")
 #assign("sc", sc, .runnerEnv)
-sc = NULL
+sc <- NULL
 
 # Acquire the SQLContext instance to expose
 #sqlContext <- callJMethod(bridge, "sqlContext")
@@ -84,7 +84,7 @@ repeat {
 
   if (is.null(sc)) {
     sc <- callJMethod(kernel, "javaSparkContext")
-    if(!is.null(sc) {
+    if(!is.null(sc)) {
       assign("sc", sc, .runnerEnv)
       sqlContext <- callJMethod(kernel, "sqlContext")
       assign("sqlContext", sqlContext, .runnerEnv)

--- a/sparkr-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sparkr/SparkRBridge.scala
+++ b/sparkr-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sparkr/SparkRBridge.scala
@@ -49,19 +49,16 @@ object SparkRBridge {
    *
    * @param brokerState The container of broker state to expose
    * @param kernel The kernel API to expose through the bridge
-   * @param sparkContext The SparkContext to expose through the bridge
    *
    * @return The new SparkR bridge
    */
   def apply(
     brokerState: BrokerState,
-    kernel: KernelLike,
-    sparkContext: SparkContext
+    kernel: KernelLike
     ): SparkRBridge = {
     new SparkRBridge(
       _brokerState = brokerState,
-      _kernel = kernel,
-      _sparkContext = sparkContext
+      _kernel = kernel
     ) with StandardJavaSparkContextProducer with StandardSQLContextProducer
   }
 }
@@ -72,14 +69,10 @@ object SparkRBridge {
  *
  * @param _brokerState The container of broker state to expose
  * @param _kernel The kernel API to expose through the bridge
- * @param _sparkContext The SparkContext to expose through the bridge
  */
 class SparkRBridge private (
   private val _brokerState: BrokerState,
-  private val _kernel: KernelLike,
-  private val _sparkContext: SparkContext
-) extends BrokerBridge(_brokerState, _kernel, _sparkContext) {
-  this: JavaSparkContextProducerLike with SQLContextProducerLike =>
-
+  private val _kernel: KernelLike
+) extends BrokerBridge(_brokerState, _kernel) {
   override val brokerName: String = "SparkR"
 }

--- a/sparkr-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sparkr/SparkRInterpreter.scala
+++ b/sparkr-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sparkr/SparkRInterpreter.scala
@@ -33,11 +33,9 @@ import scala.tools.nsc.interpreter.{InputStream, OutputStream}
  * and an implementation of R on the path.
  *
  * @param _kernel The kernel API to expose to the SparkR instance
- * @param _sparkContext The Spark context to expose to the SparkR instance
  */
 class SparkRInterpreter(
-  private val _kernel: KernelLike,
-  private val _sparkContext: SparkContext
+  private val _kernel: KernelLike
 ) extends Interpreter {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -48,8 +46,7 @@ class SparkRInterpreter(
   /** Represents the bridge used by this interpreter's R instance. */
   private lazy val sparkRBridge = SparkRBridge(
     sparkRState,
-    _kernel,
-    _sparkContext
+    _kernel
   )
 
   /** Represents the interface for R to talk to JVM Spark components. */

--- a/sql-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sql/SqlInterpreter.scala
+++ b/sql-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sql/SqlInterpreter.scala
@@ -19,6 +19,7 @@ import java.net.URL
 
 import com.ibm.spark.interpreter.{ExecuteFailure, ExecuteOutput, Interpreter}
 import com.ibm.spark.interpreter.Results.Result
+import com.ibm.spark.kernel.api.KernelLike
 import org.apache.spark.sql.SQLContext
 
 import scala.concurrent.duration._
@@ -28,8 +29,8 @@ import scala.tools.nsc.interpreter.{OutputStream, InputStream}
 /**
  * Represents an interpreter interface to Spark SQL.
  */
-class SqlInterpreter(private val sqlContext: SQLContext) extends Interpreter {
-  private lazy val sqlService = new SqlService(sqlContext)
+class SqlInterpreter(private val kernel: KernelLike) extends Interpreter {
+  private lazy val sqlService = new SqlService(kernel)
   private lazy val sqlTransformer = new SqlTransformer
 
   /**

--- a/sql-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sql/SqlService.scala
+++ b/sql-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sql/SqlService.scala
@@ -15,6 +15,7 @@
  */
 package com.ibm.spark.kernel.interpreter.sql
 
+import com.ibm.spark.kernel.api.KernelLike
 import java.io.ByteArrayOutputStream
 
 import com.ibm.spark.interpreter.broker.BrokerService
@@ -27,10 +28,10 @@ import scala.concurrent.{Future, future}
  * Represents the service that provides the high-level interface between the
  * JVM and Spark SQL.
  *
- * @param sqlContext The SQL Context of Apache Spark to use to perform SQL
+ * @param kernel The SQL Context of Apache Spark to use to perform SQL
  *                   queries
  */
-class SqlService(private val sqlContext: SQLContext) extends BrokerService {
+class SqlService(private val kernel: KernelLike) extends BrokerService {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   @volatile private var _isRunning: Boolean = false
@@ -45,7 +46,7 @@ class SqlService(private val sqlContext: SQLContext) extends BrokerService {
    */
   override def submitCode(code: Code): Future[CodeResults] = future {
     println(s"Executing: '${code.trim}'")
-    val result = sqlContext.sql(code.trim)
+    val result = kernel.sqlContext.sql(code.trim)
 
     // TODO: There is an internal method used for show called showString that
     //       supposedly is only for the Python API, look into why


### PR DESCRIPTION
Resolves issue #159.  

A command line option --sparkcontext yes/no. If no a spark context will not be created upon startup.  default is yes.
A new function on Kernel "createSparkContext(SparkConfig)" is the api a user calls to create a new spark context.  This same function will be called if --sparkcontext is yes.

The kernel now owns SparkContext and SQLContext.
Creation of the SparkContext is moved from StandardComponentInitialization to Kernel.
--sparkcontext no  is not currently supported in R (should open a separate issue).