### PR TITLE
Build interpreter classpath based on Classloader hierarchy

### DIFF
--- a/etc/bin/spark-kernel
+++ b/etc/bin/spark-kernel
@@ -32,5 +32,4 @@ export PYTHONHASHSEED=0
 
 exec "$SPARK_HOME"/bin/spark-submit \
   ${SPARK_OPTS} \
-  --driver-class-path $PROG_HOME/lib/${KERNEL_ASSEMBLY} \
   --class com.ibm.spark.SparkKernel $PROG_HOME/lib/${KERNEL_ASSEMBLY} "$@"


### PR DESCRIPTION
Fixes #216

I was able to remove the redundant addition of our assembly jar to `--driver-class-path` and get the kernel to run.