### PR TITLE
Removed scala libs from assembly

### DIFF
--- a/kernel/build.sbt
+++ b/kernel/build.sbt
@@ -20,6 +20,8 @@ import Common._
 libraryDependencies +=
   "org.spark-project.akka" %% "akka-testkit" % "2.3.4-spark" % "test" // MIT
 
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+
 //
 // CUSTOM TASKS
 //


### PR DESCRIPTION
I noticed that we had a bunch of scala packages in our assembly. Quick change to build.sbt to remove them.

They are going to get added by the Spark assembly anyway.