### PR TITLE
Fixed sqlContext not appearing

### DIFF
--- a/kernel-api/src/main/scala/com/ibm/spark/interpreter/Interpreter.scala
+++ b/kernel-api/src/main/scala/com/ibm/spark/interpreter/Interpreter.scala
@@ -20,6 +20,7 @@ import java.net.URL
 
 import com.ibm.spark.kernel.api.KernelLike
 import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
 
 import scala.tools.nsc.interpreter._
 
@@ -79,7 +80,19 @@ trait Interpreter {
    */
   def doQuietly[T](body: => T): T
 
-  def bindSparkContext(sparkContext: SparkContext): Unit = ???
+  /**
+   * Binds the SparkContext instance to the interpreter's namespace.
+   *
+   * @param sparkContext The SparkContext to bind
+   */
+  def bindSparkContext(sparkContext: SparkContext): Unit
+
+  /**
+   * Binds the SQLContext instance to the interpreter's namespace.
+   *
+   * @param sqlContext The SQLContext to bind
+   */
+  def bindSqlContext(sqlContext: SQLContext): Unit
 
   /**
    * Binds a variable in the interpreter to a value.

--- a/kernel/src/test/scala/com/ibm/spark/kernel/api/KernelSpec.scala
+++ b/kernel/src/test/scala/com/ibm/spark/kernel/api/KernelSpec.scala
@@ -10,7 +10,6 @@ import com.ibm.spark.kernel.protocol.v5.kernel.ActorLoader
 import com.ibm.spark.magic.MagicLoader
 import com.typesafe.config.Config
 import org.apache.spark.{SparkConf, SparkContext}
-import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 import org.mockito.Matchers._
 import org.scalatest.mock.MockitoSugar

--- a/kernel/src/test/scala/test/utils/DummyInterpreter.scala
+++ b/kernel/src/test/scala/test/utils/DummyInterpreter.scala
@@ -5,6 +5,8 @@ import java.net.URL
 import com.ibm.spark.interpreter.{ExecuteFailure, ExecuteOutput, Interpreter}
 import com.ibm.spark.interpreter.Results.Result
 import com.ibm.spark.kernel.api.KernelLike
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
 
 import scala.tools.nsc.interpreter.{OutputStream, InputStream}
 
@@ -109,4 +111,18 @@ class DummyInterpreter(kernel: KernelLike) extends Interpreter {
    * @return The newly initialized interpreter
    */
   override def init(kernel: KernelLike): Interpreter = ???
+
+  /**
+   * Binds the SparkContext instance to the interpreter's namespace.
+   *
+   * @param sparkContext The SparkContext to bind
+   */
+  override def bindSparkContext(sparkContext: SparkContext): Unit = ???
+
+  /**
+   * Binds the SQLContext instance to the interpreter's namespace.
+   *
+   * @param sqlContext The SQLContext to bind
+   */
+  override def bindSqlContext(sqlContext: SQLContext): Unit = ???
 }

--- a/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkInterpreter.scala
+++ b/pyspark-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/pyspark/PySparkInterpreter.scala
@@ -21,6 +21,7 @@ import com.ibm.spark.interpreter.Results.Result
 import com.ibm.spark.interpreter._
 import com.ibm.spark.kernel.api.KernelLike
 import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
 import org.slf4j.LoggerFactory
 import py4j.GatewayServer
 
@@ -78,10 +79,11 @@ class PySparkInterpreter(
     this
   }
 
+  // Unsupported (but can be invoked)
+  override def bindSparkContext(sparkContext: SparkContext): Unit = {}
 
-  override def bindSparkContext(sparkContext: SparkContext) = {
-
-  }
+  // Unsupported (but can be invoked)
+  override def bindSqlContext(sqlContext: SQLContext): Unit = {}
 
   /**
    * Executes the provided code with the option to silence output.

--- a/sparkr-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sparkr/SparkRInterpreter.scala
+++ b/sparkr-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sparkr/SparkRInterpreter.scala
@@ -21,6 +21,7 @@ import com.ibm.spark.interpreter.Results.Result
 import com.ibm.spark.interpreter._
 import com.ibm.spark.kernel.api.KernelLike
 import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Await
@@ -133,7 +134,11 @@ class SparkRInterpreter(
   // Unsupported
   override def classServerURI: String = ""
 
+  // Unsupported (but can be invoked)
   override def bindSparkContext(sparkContext: SparkContext): Unit = {}
+
+  // Unsupported (but can be invoked)
+  override def bindSqlContext(sqlContext: SQLContext): Unit = {}
 
   // Unsupported
   override def interrupt(): Interpreter = ???

--- a/sql-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sql/SqlInterpreter.scala
+++ b/sql-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/sql/SqlInterpreter.scala
@@ -102,7 +102,11 @@ class SqlInterpreter() extends Interpreter {
   // Unsupported
   override def classServerURI: String = ""
 
+  // Unsupported (but can be invoked)
   override def bindSparkContext(sparkContext: SparkContext): Unit = {}
+
+  // Unsupported (but can be invoked)
+  override def bindSqlContext(sqlContext: SQLContext): Unit = {}
 
   // Unsupported
   override def interrupt(): Interpreter = ???


### PR DESCRIPTION
Resolves #223. Forgive me this once since I wrote this thing and pushed it before remembering that we wanted to start using forks.

@lbustelo, I ran all the tests locally and also ran it using `USE_VAGRANT=true make dev`. It actually creates the HiveContext now, since we point to Spark libraries that have Hive available.

![screen shot 2015-12-08 at 12 29 16 pm](https://cloud.githubusercontent.com/assets/2481802/11664472/99298dba-9da7-11e5-912a-3431a77aad8d.png)
