### PR TITLE
Fix small bug in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RUN=$(RUN_PREFIX)$(1)$(RUN_SUFFIX)
 
 ENV_OPTS=APACHE_SPARK_VERSION=$(APACHE_SPARK_VERSION) VERSION=$(VERSION) IS_SNAPSHOT=$(IS_SNAPSHOT)
 
-FULL_VERSION=$(shell echo $(VERSION)`[ "$(IS_SNAPSHOT)" == "true" ] && (echo '-SNAPSHOT')` )
+FULL_VERSION=$(shell echo $(VERSION)`[ "$(IS_SNAPSHOT)" = "true" ] && (echo '-SNAPSHOT')` )
 ASSEMBLY_JAR=$(shell echo kernel-assembly-$(FULL_VERSION).jar )
 
 help:


### PR DESCRIPTION
Without this fix, on a fresh install of Ubuntu 14.04, I get:

tory@tory-VirtualBox:~/spark-kernel$ make build /bin/sh: 1: [: true: unexpected operator /bin/sh: 1: [: true: unexpected operator /bin/sh:
1: [: true: unexpected operator /bin/sh: 1: [: true: unexpected operator /bin/sh: 1: [: true: unexpected operator /bin/sh: 1: [: true:
unexpected operator APACHE_SPARK_VERSION=1.5.1 VERSION=0.1.5 IS_SNAPSHOT=true sbt kernel/assembly [info] Loading project definition from
/home/tory/spark-kernel/project [INFO] Using Apache Spark 1.5.1 provided from APACHE_SPARK_VERSION! [info] Set current project to root (in
build file:/home/tory/spark-kernel/) [info] Compiling 1 Scala source to /home/tory/spark-kernel/macros/target/scala-2.10/classes... [info]
Compiling 43 Scala sources to /home/tory/spark-kernel/protocol/target/scala-2.10/classes... [info] Compiling 56 Scala sources to
/home/tory/spark-kernel/kernel-api/target/scala-2.10/classes... [info] Compiling 22 Scala sources to
/home/tory/spark-kernel/communication/target/scala-2.10/classes... [info] Compiling 11 Scala sources to
/home/tory/spark-kernel/pyspark-interpreter/target/scala-2.10/classes... [info] Compiling 12 Scala sources to
/home/tory/spark-kernel/sparkr-interpreter/target/scala-2.10/classes... [info] Compiling 6 Scala sources to
/home/tory/spark-kernel/scala-interpreter/target/scala-2.10/classes... [info] Compiling 6 Scala sources to
/home/tory/spark-kernel/sql-interpreter/target/scala-2.10/classes... [info] Compiling 60 Scala sources to
/home/tory/spark-kernel/kernel/target/scala-2.10/classes... [info] Including from cache: play-datacommons_2.10-2.3.6.jar [info] Including
from cache: scala-stm_2.10-0.7.jar [info] Including from cache: joda-time-2.3.jar [info] Including from cache: joda-convert-1.6.jar [info]
Including from cache: slf4j-api-1.7.5.jar [info] Including from cache: jeromq-0.3.4.jar [info] Including from cache:
play-functional_2.10-2.3.6.jar [info] Including from cache: mesos-0.18.1-shaded-protobuf.jar [info] Including from cache: config-1.2.1.jar
[info] Including from cache: play-json_2.10-2.3.6.jar [info] Including from cache: quasiquotes_2.10-2.0.1.jar [info] Including from cache:
play-iteratees_2.10-2.3.6.jar [info] Including from cache: guava-14.0.1.jar [info] Including from cache: jopt-simple-4.6.jar [info]
Including from cache: akka-actor_2.10-2.3.11.jar [info] Including from cache: akka-slf4j_2.10-2.3.11.jar [info] Including from cache:
ivy-2.4.0-rc1.jar [info] Including from cache: commons-exec-1.3.jar [info] Including from cache: spring-core-4.1.1.RELEASE.jar [info]
Including from cache: commons-logging-1.1.3.jar [info] Checking every *.class/*.jar file's SHA-1. [info] Merging files... [warn] Merging
'README.md' with strategy 'rename' [warn] Merging 'R/README.md' with strategy 'rename' [warn] Merging 'META-INF/DEPENDENCIES' with strategy
'discard' [warn] Merging 'META-INF/MANIFEST.MF' with strategy 'discard' [warn] Merging
'META-INF/maven/com.google.guava/guava/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/com.google.guava/guava/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/com.google.protobuf/protobuf-java/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/com.google.protobuf/protobuf-java/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/commons-logging/commons-logging/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/commons-logging/commons-logging/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/joda-time/joda-time/pom.properties' with strategy 'discard' [warn] Merging 'META-INF/maven/joda-time/joda-time/pom.xml'
with strategy 'discard' [warn] Merging 'META-INF/maven/net.sf.jopt-simple/jopt-simple/pom.properties' with strategy 'discard' [warn]
Merging 'META-INF/maven/net.sf.jopt-simple/jopt-simple/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/org.apache.commons/commons-exec/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/org.apache.commons/commons-exec/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/org.apache.mesos/mesos/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/org.apache.mesos/mesos/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/org.joda/joda-convert/pom.properties' with strategy 'discard' [warn] Merging 'META-INF/maven/org.joda/joda-convert/pom.xml'
with strategy 'discard' [warn] Merging 'META-INF/maven/org.slf4j/slf4j-api/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/org.slf4j/slf4j-api/pom.xml' with strategy 'discard' [warn] Merging 'META-INF/maven/org.zeromq/jeromq/pom.properties' with
strategy 'discard' [warn] Merging 'META-INF/maven/org.zeromq/jeromq/pom.xml' with strategy 'discard' [warn] Merging 'reference.conf' with
strategy 'concat' [warn] Strategy 'concat' was applied to a file [info] Strategy 'deduplicate' was applied to 2 files (Run the task at
debug level to see details) [warn] Strategy 'discard' was applied to 22 files [warn] Strategy 'rename' was applied to 2 files [info] SHA-1:
eda7263116b2ad0ea018d7f776bf05e0f891325e [info] Packaging
/home/tory/spark-kernel/kernel/target/scala-2.10/kernel-assembly-0.1.5-SNAPSHOT.jar ... [info] Done packaging. [success] Total time: 32 s,
completed 12-Dec-2015 1:29:53 PM tory@tory-VirtualBox:~/spark-kernel$ make dist /bin/sh: 1: [: true: unexpected operator /bin/sh: 1: [:
true: unexpected operator /bin/sh: 1: [: true: unexpected operator /bin/sh: 1: [: true: unexpected operator /bin/sh: 1: [: true: unexpected
operator /bin/sh: 1: [: true: unexpected operator APACHE_SPARK_VERSION=1.5.1 VERSION=0.1.5 IS_SNAPSHOT=true sbt kernel/assembly [info]
Loading project definition from /home/tory/spark-kernel/project [INFO] Using Apache Spark 1.5.1 provided from APACHE_SPARK_VERSION! [info]
Set current project to root (in build file:/home/tory/spark-kernel/) [info] Compiling 1 Scala source to
/home/tory/spark-kernel/macros/target/scala-2.10/classes... [info] Compiling 43 Scala sources to
/home/tory/spark-kernel/protocol/target/scala-2.10/classes... [info] Compiling 56 Scala sources to
/home/tory/spark-kernel/kernel-api/target/scala-2.10/classes... [info] Compiling 22 Scala sources to
/home/tory/spark-kernel/communication/target/scala-2.10/classes... [info] Compiling 6 Scala sources to
/home/tory/spark-kernel/scala-interpreter/target/scala-2.10/classes... [info] Compiling 6 Scala sources to
/home/tory/spark-kernel/sql-interpreter/target/scala-2.10/classes... [info] Compiling 12 Scala sources to
/home/tory/spark-kernel/sparkr-interpreter/target/scala-2.10/classes... [info] Compiling 11 Scala sources to
/home/tory/spark-kernel/pyspark-interpreter/target/scala-2.10/classes... [info] Compiling 60 Scala sources to
/home/tory/spark-kernel/kernel/target/scala-2.10/classes... [info] Including from cache: play-datacommons_2.10-2.3.6.jar [info] Including
from cache: scala-stm_2.10-0.7.jar [info] Including from cache: play-functional_2.10-2.3.6.jar [info] Including from cache:
mesos-0.18.1-shaded-protobuf.jar [info] Including from cache: config-1.2.1.jar [info] Including from cache: slf4j-api-1.7.5.jar [info]
Including from cache: jeromq-0.3.4.jar [info] Including from cache: quasiquotes_2.10-2.0.1.jar [info] Including from cache:
joda-time-2.3.jar [info] Including from cache: play-json_2.10-2.3.6.jar [info] Including from cache: joda-convert-1.6.jar [info] Including
from cache: play-iteratees_2.10-2.3.6.jar [info] Including from cache: guava-14.0.1.jar [info] Including from cache: jopt-simple-4.6.jar
[info] Including from cache: akka-actor_2.10-2.3.11.jar [info] Including from cache: akka-slf4j_2.10-2.3.11.jar [info] Including from
cache: commons-exec-1.3.jar [info] Including from cache: ivy-2.4.0-rc1.jar [info] Including from cache: commons-logging-1.1.3.jar [info]
Including from cache: spring-core-4.1.1.RELEASE.jar [info] Checking every *.class/*.jar file's SHA-1. [info] Merging files... [warn]
Merging 'README.md' with strategy 'rename' [warn] Merging 'R/README.md' with strategy 'rename' [warn] Merging 'META-INF/DEPENDENCIES' with
strategy 'discard' [warn] Merging 'META-INF/MANIFEST.MF' with strategy 'discard' [warn] Merging
'META-INF/maven/com.google.guava/guava/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/com.google.guava/guava/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/com.google.protobuf/protobuf-java/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/com.google.protobuf/protobuf-java/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/commons-logging/commons-logging/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/commons-logging/commons-logging/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/joda-time/joda-time/pom.properties' with strategy 'discard' [warn] Merging 'META-INF/maven/joda-time/joda-time/pom.xml'
with strategy 'discard' [warn] Merging 'META-INF/maven/net.sf.jopt-simple/jopt-simple/pom.properties' with strategy 'discard' [warn]
Merging 'META-INF/maven/net.sf.jopt-simple/jopt-simple/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/org.apache.commons/commons-exec/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/org.apache.commons/commons-exec/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/org.apache.mesos/mesos/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/org.apache.mesos/mesos/pom.xml' with strategy 'discard' [warn] Merging
'META-INF/maven/org.joda/joda-convert/pom.properties' with strategy 'discard' [warn] Merging 'META-INF/maven/org.joda/joda-convert/pom.xml'
with strategy 'discard' [warn] Merging 'META-INF/maven/org.slf4j/slf4j-api/pom.properties' with strategy 'discard' [warn] Merging
'META-INF/maven/org.slf4j/slf4j-api/pom.xml' with strategy 'discard' [warn] Merging 'META-INF/maven/org.zeromq/jeromq/pom.properties' with
strategy 'discard' [warn] Merging 'META-INF/maven/org.zeromq/jeromq/pom.xml' with strategy 'discard' [warn] Merging 'reference.conf' with
strategy 'concat' [warn] Strategy 'concat' was applied to a file [info] Strategy 'deduplicate' was applied to 2 files (Run the task at
debug level to see details) [warn] Strategy 'discard' was applied to 22 files [warn] Strategy 'rename' was applied to 2 files [info] SHA-1:
dac0ea97501727b93d75eaa7a769e355b350ae3f [info] Packaging
/home/tory/spark-kernel/kernel/target/scala-2.10/kernel-assembly-0.1.5-SNAPSHOT.jar ... [info] Done packaging. [success] Total time: 35 s,
completed 12-Dec-2015 1:30:39 PM /bin/sh: 1: [: true: unexpected operator /bin/sh: 1: [: true: unexpected operator /bin/sh: 1: [: true:
unexpected operator cp: cannot stat ‘kernel/target/scala-2.10/kernel-assembly-0.1.5.jar’: No such file or directory make: *** [dist] Error
1