### PR TITLE
Ensure statements get interpreted correctly.

### DIFF
--- a/scala-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/com/ibm/spark/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -285,8 +285,11 @@ class ScalaInterpreter() extends Interpreter {
   }
 
   protected def interpretRec(lines: List[String], silent: Boolean = false, results: (Results.Result, Either[ExecuteOutput, ExecuteFailure])): (Results.Result, Either[ExecuteOutput, ExecuteFailure]) = {
+    val ShouldContinue = "\\s*((?:[,\\.;#\\[\\)\\]}]|:=|>:|<%|=>|<-|<:|catch|else|extends|finally|forSome|match|with|yield).*)".r
+
     lines match {
       case Nil => results
+      case x :: ShouldContinue(y) :: xs => interpretRec(x + "\n" + y :: xs, silent, results)
       case x :: xs =>
         val output = interpretLine(x)
 


### PR DESCRIPTION
The ScalaInterpreter does not often break up statements correctly if the next line is a continuation of the current line.  This combines lines according to the scala rules.

 Combining statements if …
…the next line starts with

catch    else    extends    finally    forSome    match
with    yield    ,    .    ;    :    =    =>    <-    <:    <%
>:    #    [    )    ]    }

(cherry picked from commit 28b9cd6bab0e1b1af21d237ae84d6e3c97545fa3)