### PR TITLE
Allow downloads of notebook as a .scala file.  ie.  Put on the correct extension

### DIFF
--- a/protocol/src/main/scala/com/ibm/spark/kernel/protocol/v5/SparkKernelInfo.scala
+++ b/protocol/src/main/scala/com/ibm/spark/kernel/protocol/v5/SparkKernelInfo.scala
@@ -37,7 +37,7 @@ object SparkKernelInfo {
   /**
    * Represents the language supported by the kernel.
    */
-  val language_info           = Map("name" -> "scala")
+  val language_info           = Map("name" -> "scala", "file_extension" -> ".scala")
 
   /**
    * Represents the language version supported by the kernel.


### PR DESCRIPTION
File downloads should download text files with a .scala extension instead of .txt

(cherry picked from commit e0a1f8885b12d5f358e9d6ddd981ef8e85ed4f3e)